### PR TITLE
Add missing 'dl' dependency to CMakeLists.txt

### DIFF
--- a/jaco_driver/CMakeLists.txt
+++ b/jaco_driver/CMakeLists.txt
@@ -75,7 +75,7 @@ add_executable(jaco_tf_updater
 add_dependencies(jaco_arm_driver ${catkin_EXPORTED_TARGETS})
 add_dependencies(jaco_tf_updater ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(jaco_arm_driver ${catkin_LIBRARIES})
+target_link_libraries(jaco_arm_driver ${catkin_LIBRARIES} dl)
 target_link_libraries(jaco_tf_updater ${catkin_LIBRARIES})
 
 #############


### PR DESCRIPTION
Fixes the following issue when compiling for me:

Linking CXX executable /home/z3288187/catkin_ws/devel/lib/jaco_driver/jaco_arm_driver
/usr/bin/ld: CMakeFiles/jaco_arm_driver.dir/src/jaco_api.cpp.o: undefined reference to symbol 'dlopen@@GLIBC_2.1'
//lib/i386-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: **\* [/home/z3288187/catkin_ws/devel/lib/jaco_driver/jaco_arm_driver] Error 1
make[1]: **\* [jaco-ros/jaco_driver/CMakeFiles/jaco_arm_driver.dir/all] Error 2
make: **\* [all] Error 2
Invoking "make" failed
