### PR TITLE
Gamepad teleoperation support

### DIFF
--- a/jaco_driver/CMakeLists.txt
+++ b/jaco_driver/CMakeLists.txt
@@ -77,8 +77,8 @@ add_executable(jaco_tf_updater
 add_dependencies(jaco_arm_driver ${catkin_EXPORTED_TARGETS})
 add_dependencies(jaco_tf_updater ${catkin_EXPORTED_TARGETS})
 
-target_link_libraries(jaco_arm_driver ${catkin_LIBRARIES})
-target_link_libraries(jaco_tf_updater ${catkin_LIBRARIES})
+target_link_libraries(jaco_arm_driver ${catkin_LIBRARIES} -ldl)
+target_link_libraries(jaco_tf_updater ${catkin_LIBRARIES} -ldl)
 
 #############
 ## Install ##

--- a/jaco_driver/CMakeLists.txt
+++ b/jaco_driver/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(jaco_arm_driver
   src/jaco_angles_action.cpp
   src/jaco_fingers_action.cpp
   src/jaco_types.cpp
+  src/joystick_command_translator.cpp
   include/jaco_driver/jaco_angles_action.h
   include/jaco_driver/jaco_api.h
   include/jaco_driver/jaco_arm.h
@@ -60,6 +61,7 @@ add_executable(jaco_arm_driver
   include/jaco_driver/jaco_fingers_action.h
   include/jaco_driver/jaco_pose_action.h
   include/jaco_driver/jaco_types.h
+  include/jaco_driver/joystick_command_translator.h
   include/kinova/Kinova.API.CommLayerUbuntu.h
   include/kinova/Kinova.API.UsbCommandLayerUbuntu.h
   include/kinova/KinovaTypes.h

--- a/jaco_driver/include/jaco_driver/jaco_comm.h
+++ b/jaco_driver/include/jaco_driver/jaco_comm.h
@@ -74,6 +74,7 @@ class JacoComm
     void setJointVelocities(const AngularInfo& joint_vel);
     void setCartesianVelocities(const CartesianInfo &velocities);
     void setConfig(const ClientConfigurations &config);
+    void sendJoystickCommand(const JoystickCommand &command);
     void getJointAngles(JacoAngles &angles);
     void getCartesianPosition(JacoPose &position);
     void getFingerPositions(FingerAngles &fingers);

--- a/jaco_driver/include/jaco_driver/joystick_command_translator.h
+++ b/jaco_driver/include/jaco_driver/joystick_command_translator.h
@@ -1,0 +1,29 @@
+#ifndef JOYSTICK_COMMAND_TRANSLATOR_H
+#define JOYSTICK_COMMAND_TRANSLATOR_H
+
+#include <ros/ros.h>
+
+#include <jaco_msgs/JoystickCommand.h>
+
+#include <string>
+#include "jaco_driver/jaco_comm.h"
+
+namespace jaco {
+
+class JoystickCommandTranslator
+{
+public:
+    JoystickCommandTranslator(JacoComm &arm_comm, ros::NodeHandle &node_handle);
+
+private:
+   void commandReceived(const jaco_msgs::JoystickCommandConstPtr& msg);
+   JoystickCommand translateCommand(const jaco_msgs::JoystickCommandConstPtr& command);
+
+   ros::NodeHandle node_handle;
+   JacoComm &arm_comm;
+   ros::Subscriber subscriber;
+};
+
+}
+
+#endif // JOYSTICK_COMMAND_TRANSLATOR_H

--- a/jaco_driver/launch/jaco_arm.launch
+++ b/jaco_driver/launch/jaco_arm.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <node name="jaco_arm_driver" pkg="jaco_driver" type="jaco_arm_driver" output="screen" cwd="node">
-    <param name="serial_number" value="PJ00000001030703130" />
+    <param name="serial_number" value="" />
   </node>
     
   <node name="jaco_tf_updater" pkg="jaco_driver" type="jaco_tf_updater" output="screen" cwd="node">

--- a/jaco_driver/src/jaco_comm.cpp
+++ b/jaco_driver/src/jaco_comm.cpp
@@ -499,6 +499,24 @@ void JacoComm::setConfig(const ClientConfigurations &config)
     }
 }
 
+/*!
+ * \brief Sends a native joystick command to the arm.
+ *
+ * The command simulates the native Kinova Jaco 3-axis joystick's output.
+ */
+void JacoComm::sendJoystickCommand(const JoystickCommand &command)
+{
+    boost::recursive_mutex::scoped_lock lock(api_mutex_);
+
+    startAPI();
+
+    int result = jaco_api_.sendJoystickCommand(command);
+    if (result != NO_ERROR_KINOVA)
+    {
+        throw JacoCommException("Could not send joystick command", result);
+    }
+}
+
 
 /*!
  * \brief API call to obtain the current angular position of all the joints.

--- a/jaco_driver/src/joystick_command_translator.cpp
+++ b/jaco_driver/src/joystick_command_translator.cpp
@@ -1,0 +1,40 @@
+#include "../include/jaco_driver/joystick_command_translator.h"
+#include <kinova/KinovaTypes.h>
+#include "jaco_driver/jaco_types.h"
+#include <string>
+
+namespace jaco {
+
+JoystickCommandTranslator::JoystickCommandTranslator(JacoComm &arm_comm, ros::NodeHandle &node_handle)
+    : arm_comm(arm_comm),
+      node_handle(node_handle, "joystick_translator")
+{
+    std::string joy_topic("/jaco_arm_driver/in/joystick_command");
+    subscriber = node_handle.subscribe(joy_topic, 10, &JoystickCommandTranslator::commandReceived, this);
+}
+
+void JoystickCommandTranslator::commandReceived(const jaco_msgs::JoystickCommandConstPtr& msg)
+{
+    arm_comm.sendJoystickCommand(this->translateCommand(msg));
+}
+
+JoystickCommand JoystickCommandTranslator::translateCommand(const jaco_msgs::JoystickCommandConstPtr& command)
+{
+    JoystickCommand result;
+
+    for(int i = 0; i < JOYSTICK_BUTTON_COUNT; i++)
+    {
+        result.ButtonValue[i] = command->ButtonValue[i];
+    }
+
+    result.InclineLeftRight = command->InclineLeftRight;
+    result.InclineForwardBackward = command->InclineForwardBackward;
+    result.Rotate = command->Rotate;
+    result.MoveLeftRight = command->MoveLeftRight;
+    result.MoveForwardBackward = command->MoveForwardBackward;
+    result.PushPull = command->PushPull;
+
+    return result;
+}
+
+}

--- a/jaco_driver/src/nodes/jaco_arm_driver.cpp
+++ b/jaco_driver/src/nodes/jaco_arm_driver.cpp
@@ -11,6 +11,7 @@
 #include "jaco_driver/jaco_pose_action.h"
 #include "jaco_driver/jaco_angles_action.h"
 #include "jaco_driver/jaco_fingers_action.h"
+#include "jaco_driver/joystick_command_translator.h"
 
 
 int main(int argc, char **argv)
@@ -29,6 +30,7 @@ int main(int argc, char **argv)
             jaco::JacoPoseActionServer pose_server(comm, nh);
             jaco::JacoAnglesActionServer angles_server(comm, nh);
             jaco::JacoFingersActionServer fingers_server(comm, nh);
+            jaco::JoystickCommandTranslator joystick_translator(comm, nh);
 
             ros::spin();
         }

--- a/jaco_msgs/CMakeLists.txt
+++ b/jaco_msgs/CMakeLists.txt
@@ -17,6 +17,7 @@ add_message_files(
   FingerPosition.msg
   JointAngles.msg
   JointVelocity.msg
+  JoystickCommand.msg
 )
 
 add_service_files(

--- a/jaco_msgs/msg/JoystickCommand.msg
+++ b/jaco_msgs/msg/JoystickCommand.msg
@@ -1,0 +1,8 @@
+Header header
+int16[16] ButtonValue
+float32 InclineLeftRight
+float32 InclineForwardBackward
+float32 Rotate
+float32 MoveLeftRight
+float32 MoveForwardBackward
+float32 PushPull

--- a/jaco_teleop/CMakeLists.txt
+++ b/jaco_teleop/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(jaco_teleop)
+
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  geometry_msgs
+  jaco_msgs
+  rospy
+  std_msgs
+  sensor_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+catkin_package(
+ CATKIN_DEPENDS actionlib geometry_msgs joy jaco_msgs rospy std_msgs sensor_msgs topic_tools message_runtime
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+#############
+## Install ##
+#############
+
+install(PROGRAMS
+  nodes/jaco_teleop_joy.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/nodes
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+install(FILES
+  launch/jaco_teleop.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)

--- a/jaco_teleop/CMakeLists.txt
+++ b/jaco_teleop/CMakeLists.txt
@@ -3,10 +3,8 @@ project(jaco_teleop)
 
 find_package(catkin REQUIRED COMPONENTS
   actionlib
-  geometry_msgs
   jaco_msgs
   rospy
-  std_msgs
   sensor_msgs
 )
 
@@ -14,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## catkin specific configuration ##
 ###################################
 catkin_package(
- CATKIN_DEPENDS actionlib geometry_msgs joy jaco_msgs rospy std_msgs sensor_msgs topic_tools message_runtime
+ CATKIN_DEPENDS actionlib joy jaco_msgs rospy sensor_msgs topic_tools message_runtime
 )
 
 catkin_python_setup()
@@ -34,6 +32,12 @@ include_directories(
 install(PROGRAMS
   nodes/jaco_teleop_joy.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}/nodes
+)
+
+install(PROGRAMS
+  src/jaco_teleop/__init__.py
+  src/jaco_teleop/joystick_interface.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)

--- a/jaco_teleop/CMakeLists.txt
+++ b/jaco_teleop/CMakeLists.txt
@@ -17,6 +17,8 @@ catkin_package(
  CATKIN_DEPENDS actionlib geometry_msgs joy jaco_msgs rospy std_msgs sensor_msgs topic_tools message_runtime
 )
 
+catkin_python_setup()
+
 ###########
 ## Build ##
 ###########

--- a/jaco_teleop/README.md
+++ b/jaco_teleop/README.md
@@ -1,0 +1,36 @@
+Teleoperation support for Jaco arm.
+==================================
+
+Launching jaco_teleop.launch assumes that jaco_driver/jaco_arm.launch has already been running.
+
+This node simply remaps gamepad commands to the Jaco dedicated controller commands. The gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the "front panel" (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set.
+	
+Controls remapping:
+-------------------
+		
+- Left joystick
+ - Translation x/y
+ 
+- Right joystick
+ - Rotation x/y
+ 
+- Left back buttons (one analog, one digital)
+ - Translation z
+ 
+- Right back buttons (one analog, one digital)
+ - Rotation theta (wrist joint)
+ 
+- Left cross up/down
+ - Open/close all fingers
+ 
+- A (2), X (1) buttons
+ - Open/close all fingers
+ 
+- B (3)
+ - Emergency stop (when holding)
+ 
+- Y (4)
+ - Release emergency stop
+ 
+- Start button
+ - Home arm/go to retreat (it's always needed to home the arm before you can control it)

--- a/jaco_teleop/README.md
+++ b/jaco_teleop/README.md
@@ -1,36 +1,45 @@
 Teleoperation support for Jaco arm.
 ==================================
+To run the teleoperation node, type simply
 
-Launching jaco_teleop.launch assumes that jaco_driver/jaco_arm.launch has already been running.
+	roslaunch jaco_teleop jaco_teleop.launch
 
-This node simply remaps gamepad commands to the Jaco dedicated controller commands. The gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the "front panel" (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set.
+or 
+
+	roslaunch jaco_teleop jaco_teleop.launch joystick_type:=xbox_360
+
+if you have the appropriate YAML config file in the `config` directory (in this example `config/xbox_360.yaml`). 
+
+Launching `jaco_teleop.launch` assumes that `jaco_driver/jaco_arm.launch` has already been running.
+
+This node simply remaps gamepad commands to the Jaco dedicated controller commands. Using the default gamepad config, the gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the "front panel" (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set (when using the default gamepad config).
 	
-Controls remapping:
+Default controls remapping (Logitech F710):
 -------------------
 		
-- Left joystick
- - Translation x/y
- 
-- Right joystick
- - Rotation x/y
- 
-- Left back buttons (one analog, one digital)
- - Translation z
- 
-- Right back buttons (one analog, one digital)
- - Rotation theta (wrist joint)
- 
-- Left cross up/down
- - Open/close all fingers
- 
-- A (2), X (1) buttons
- - Open/close all fingers
- 
-- B (3)
- - Emergency stop (when holding)
- 
-- Y (4)
- - Release emergency stop
- 
-- Start button
- - Home arm/go to retreat (it's always needed to home the arm before you can control it)
+    Thanks to RIVeR-Lab/wpi_jaco for base of this image
+
+                   Controls                
+        up/down                 rotate wrist
+       ________                 __________    
+      /fin.open\_______________/          \   
+     |   _| |_    < >  < home >     (4)    |  
+     |  |_   _|   < >    < >     (1)   (3) |  
+     |    |_|    ___       ___      (2)    |  
+     | fin.close/   \     /   \            |  
+     |          \___/     \___/            |  
+     |       x/y trans  rotate x/y         |  
+     |        _______/---\_______          |  
+     |       |                    \        |  
+      \      /                     \      /   
+       \____/                       \____/    
+                                           
+    Buttons:                               
+      (1) Fingers open
+      (2) Fingers close
+      (3) Emergency stop                    
+      (4) Emergency release
+
+Contributing
+------------
+If you write your own YAML config for another controller, feel free to fork this repo and place a merge request.

--- a/jaco_teleop/config/logitech_f710_directinput.yaml
+++ b/jaco_teleop/config/logitech_f710_directinput.yaml
@@ -1,0 +1,48 @@
+emergency_stop: [ {type: 'button', id: 2} ]
+emergency_release: [ {type: 'button', id: 3} ]
+translate_left_right: [ {type: 'axis', id: 0} ]
+translate_forward_backward: [ {type: 'axis', id: 1, invert: True} ]
+translate_up_down: [ 
+    {type: 'button', id: 6, on_value: -1},
+    {type: 'button', id: 4}
+]
+rotate_x: [ {type: 'axis', id: 2, invert: True} ]
+rotate_y: [ {type: 'axis', id: 3} ]
+rotate_wrist: [ 
+    {type: 'button', id: 7, on_value: -1},
+    {type: 'button', id: 5}
+]
+fingers_open_close: [
+    {type: 'axis', id: 5},
+    {type: 'button', id: 1, on_value: -1},
+    {type: 'button', id: 0}
+]
+home_arm: [ {type: 'button', id: 9} ]
+dead_man: [ ]
+
+description: |
+    # JOYSTICK CONFIG FOR MODEL LOGITECH F710 (DirectInput mode)
+    # ==========================================================
+    #
+    # Thanks to RIVeR-Lab/wpi_jaco for base of this image
+    #
+    #                Controls                
+    #     up/down                 rotate wrist
+    #    ________                 __________    
+    #   /fin.open\_______________/          \   
+    #  |   _| |_    < >  < home >     (4)    |  
+    #  |  |_   _|   < >    < >     (1)   (3) |  
+    #  |    |_|    ___       ___      (2)    |  
+    #  | fin.close/   \     /   \            |  
+    #  |          \___/     \___/            |  
+    #  |       x/y trans  rotate x/y         |  
+    #  |        _______/---\_______          |  
+    #  |       |                    \        |  
+    #   \      /                     \      /   
+    #    \____/                       \____/    
+    #                                        
+    # Buttons:                               
+    #   (1) Fingers open
+    #   (2) Fingers close
+    #   (3) Emergency stop                    
+    #   (4) Emergency release

--- a/jaco_teleop/config/logitech_f710_xinput.yaml
+++ b/jaco_teleop/config/logitech_f710_xinput.yaml
@@ -1,0 +1,48 @@
+emergency_stop: [ {type: 'button', id: 1} ]
+emergency_release: [ {type: 'button', id: 3} ]
+translate_left_right: [ {type: 'axis', id: 0} ]
+translate_forward_backward: [ {type: 'axis', id: 1, invert: True} ]
+translate_up_down: [ 
+    {type: 'axis', id: 2, hw_min: -1, hw_max: 1, remap_min: -1, remap_max: 0, startup_block_value: 0},
+    {type: 'button', id: 4}
+]
+rotate_x: [ {type: 'axis', id: 3, invert: True} ]
+rotate_y: [ {type: 'axis', id: 4} ]
+rotate_wrist: [ 
+    {type: 'axis', id: 5, hw_min: -1, hw_max: 1, remap_min: -1, remap_max: 0, startup_block_value: 0},
+    {type: 'button', id: 5}
+]
+fingers_open_close: [
+    {type: 'axis', id: 7},
+    {type: 'button', id: 0, on_value: -1},
+    {type: 'button', id: 2}
+]
+home_arm: [ {type: 'button', id: 7} ]
+dead_man: [ ]
+
+description: |
+    # JOYSTICK CONFIG FOR MODEL LOGITECH F710 (XInput mode)
+    # =====================================================
+    #
+    # Thanks to RIVeR-Lab/wpi_jaco for base of this image
+    #
+    #                Controls                
+    #     up/down                 rotate wrist
+    #    ________                 __________    
+    #   /fin.open\_______________/          \   
+    #  |   _| |_    < >  < home >     (4)    |  
+    #  |  |_   _|   < >    < >     (1)   (3) |  
+    #  |    |_|    ___       ___      (2)    |  
+    #  | fin.close/   \     /   \            |  
+    #  |          \___/     \___/            |  
+    #  |       x/y trans  rotate x/y         |  
+    #  |        _______/---\_______          |  
+    #  |       |                    \        |  
+    #   \      /                     \      /   
+    #    \____/                       \____/    
+    #                                        
+    # Buttons:                               
+    #   (1) Fingers open
+    #   (2) Fingers close
+    #   (3) Emergency stop                    
+    #   (4) Emergency release

--- a/jaco_teleop/config/readme.yaml
+++ b/jaco_teleop/config/readme.yaml
@@ -1,0 +1,91 @@
+# This is a sample joystick configuration to show all the capabilities of JoystickInterface.
+
+# Each entry consists of a key/function (before colon) and the corresponding buttons/axes config.
+button1_function: [ {type: 'button', id: 1} ]
+axis0_function: [ {type: 'axis', id: 0} ]
+
+# In Python code you can then ask the functions for their values like this:
+#       joystickInterface.get_value(joy, 'button1_function')
+# where joy is the current joystick state provided in sensor_msgs/Joy by ROS.
+
+# A function can have multiple buttons/axes assigned. They are "executed" (asked for value) in the same order in which you specify them here.
+multi: [ 
+    {type: 'axis', id: 2},
+    {type: 'button', id: 4}
+]
+# This means if the user moves axis 2, it will be the "value provider". If axis 2 is in the default position, then button 4 becomes the "value provider".
+# An example usage is e.g. when you want to have an up/down function controlled by values -1..1, where an axis controls the range 0..1 and a button 
+# stands for the -1 value.
+
+# This is a special function (due to its name). If specified, without this button being pressed, no other buttons work. 
+# You can also specify more buttons, or even axes for dead man's button. The rule is that as long as this function returns a non-neutral (non-default) value, other buttons work.
+dead_man: [ {type: 'button', id: 0} ]
+
+# This is an example button-type config showing all possible attributes. Optional attributes are shown with their default values. If you omit optional attributes, 
+# they will be automatically filled with these defaults.
+full_button: [ {type: 'button', id: 0, on_value: 1, off_value: 0, neutral_value: 0} ]
+# type (string): Required, allowed values are (as to now) 'button' or 'axis'.
+#
+# id (int): Required. Index to the joy.buttons array provided by ROS in sensor_msgs/Joy message.
+#
+# on_value (any): Optional. The value to return when the button is pressed. It doesn't have to be an int, you can return anything.
+# off_value (any): Optional. The value to return when the button is not pressed. It doesn't have to be an int, you can return anything.
+#
+# neutral_value (any): Optional. The value to treat as neutral. If the button should return the neutral value set here, the next defined button/axis is asked for value. 
+#   The first button/axis that returns a non-neutral value is considered active/pressed. If all buttons return neutral values, then the neutral value of the first 
+#   defined button/axis is returned by get_value. You should make sure neutral_value is set to the same value as either on_value or off_value.
+
+# This is an example button-type config showing all possible attributes. Optional attributes are shown with their default values. If you omit optional attributes, 
+# they will be automatically filled with these defaults. Using hw_min/max, remap_min/max and invert attributes you can do raw/output interval remapping, e.g.
+# to remap raw interval -1..1 to output interval 0..1 .
+full_axis: [ {type: 'axis', id: 0, hw_min: -1.0, hw_max: 1.0, remap_min: -1.0, remap_max: 1.0, invert: False, startup_block_value: None, neutral_value: 0.0} ]
+# type (string): Required, allowed values are (as to now) 'button' or 'axis'.
+#
+# id (int): Required. Index to the joy.axes array provided by ROS in sensor_msgs/Joy message.
+#
+# hw_min (float): Optional. The minimum value returned from ROS for this axis.
+# hw_max (float): Optional. The maximum value returned from ROS for this axis.
+#
+# remap_min (float): Optional. The lower bound of the interval of return values.
+# remap_max (float): Optional. The upper bound of the interval of return values.
+#
+# invert (bool): Optional. If True, the joystick min maps to output max and vice versa.
+#
+# startup_block_value (float): Optional. This is a workaround for axis keys that publish other than neutral values before the axis is moved for the first time. 
+#   Specify here the value the axis publishes until it is moved for the first time. This is e.g. the case of Logitech F710 back side axes in XInput mode 
+#   (the buttons have neutral values -1.0, however until you "initialize" them by pressing them, they publish 0.0). 
+#   Note that contrary to neutral_value, here you have to specify the raw (HW) values in range hw_min to hw_max.
+#
+# neutral_value (float): Optional. The value to treat as neutral. If the axis should return the neutral value set here, the next defined button/axis is asked for value. 
+#   The first button/axis that returns a non-neutral value is considered active/pressed. If all buttons return neutral values, then the neutral value of the first 
+#   defined button/axis is returned by get_value. You should make sure neutral_value is a value from the output range (remap_min to remap_max).
+
+# Finally, provide a drawing illustrating the functions of your config. In YAML, you specify multiline strings by writing vertical bar, newline, and then put your
+# multiline string indented by one tab.
+# This description will be available in function get_description(), so that you can e.g. write it out after loading the config.
+description: |
+    # JOYSTICK CONFIG FOR MODEL LOGITECH F710 (XInput mode)
+    # =====================================================
+    #
+    # Thanks to RIVeR-Lab/wpi_jaco for base of this image
+    #
+    #                Controls                
+    #     up/down                 rotate wrist
+    #    ________                 __________    
+    #   /fin.open\_______________/          \   
+    #  |   _| |_    < >  < home >     (4)    |  
+    #  |  |_   _|   < >    < >     (1)   (3) |  
+    #  |    |_|    ___       ___      (2)    |  
+    #  | fin.close/   \     /   \            |  
+    #  |          \___/     \___/            |  
+    #  |       x/y trans  rotate x/y         |  
+    #  |        _______/---\_______          |  
+    #  |       |                    \        |  
+    #   \      /                     \      /   
+    #    \____/                       \____/    
+    #                                        
+    # Buttons:                               
+    #   (1) Fingers open
+    #   (2) Fingers close
+    #   (3) Emergency stop                    
+    #   (4) Emergency release                   

--- a/jaco_teleop/launch/jaco_teleop.launch
+++ b/jaco_teleop/launch/jaco_teleop.launch
@@ -1,0 +1,9 @@
+<launch>
+	<node pkg="joy" type="joy_node" name="jaco_joy_node" >
+		<param name="autorepeat_rate" value="0.0" />
+	</node>
+
+	<node pkg="jaco_teleop" type="jaco_teleop_joy.py"
+		name="jaco_teleop_joy">
+	</node>
+</launch>

--- a/jaco_teleop/launch/jaco_teleop.launch
+++ b/jaco_teleop/launch/jaco_teleop.launch
@@ -1,9 +1,13 @@
 <launch>
+
+    <arg name="joystick_type" default="logitech_f710_xinput" />
+
 	<node pkg="joy" type="joy_node" name="jaco_joy_node" >
 		<param name="autorepeat_rate" value="0.0" />
 	</node>
 
 	<node pkg="jaco_teleop" type="jaco_teleop_joy.py"
 		name="jaco_teleop_joy">
+        <param name="config_file" value="$(find jaco_teleop)/config/$(arg joystick_type).yaml" />
 	</node>
 </launch>

--- a/jaco_teleop/nodes/jaco_teleop_joy.py
+++ b/jaco_teleop/nodes/jaco_teleop_joy.py
@@ -1,95 +1,111 @@
 #!/usr/bin/env python
-# # @file
-# Joystick teleoperation module for the Kinova Jaco arm
-#
-import roslib
 
-roslib.load_manifest('jaco_teleop')
+# Joystick teleoperation module for the Kinova Jaco arm.
+
+import sys
 import rospy
 import actionlib
 from sensor_msgs.msg import Joy
 
 from jaco_msgs.msg import JoystickCommand, SetFingersPositionAction, SetFingersPositionGoal
 from jaco_msgs.srv import Start, Stop;
+from jaco_teleop.joystick_interface import JoystickInterface
 
 from time import sleep
+import yaml
 
-## Joystick teleoperation class
 class JacoTeleopJoy(object):
-    '''Joystick teleoperation interface.
-	'''
+    """
+    Joystick/gamepad teleoperation interface that utilizes the same command that are sent from the dedicated Kinova
+    controller.
+    """
 
-    ## Instantiate a JacoTeleopJoy object
     def __init__(self):
+        """
+        Read joystick config from the YAML config file. Subscribe to the joy, set up publishers and action servers.
+        Required ROS param: ~config_file (string): Path to the YAML config to load.
+        """
+        configStream = open(rospy.get_param('~config_file'), 'r')
+        # This is a list of all config keys we want to pass to the joystick abstraction layer.
+        joystick_config = yaml.load(configStream)
+
+        self.joystick_interface = JoystickInterface(joystick_config)
+
+        rospy.logwarn("Using joystick interface with the following description:\n" + 
+                self.joystick_interface.get_description())
+
+        # Topic that executes all received commands with the real arm.
         self.joystick_topic = "/jaco_arm_driver/in/joystick_command"
         self.joystick_pub = rospy.Publisher(self.joystick_topic, JoystickCommand, queue_size=10)
 
+        # Emergency stop service.
         self.emergency_stop_topic = "/jaco_arm_driver/in/stop"
         rospy.wait_for_service(self.emergency_stop_topic)
         self.emergency_stop = rospy.ServiceProxy(self.emergency_stop_topic, Stop)
 
+        # Emergency stop release service.
         self.emergency_start_topic = "/jaco_arm_driver/in/start"
         rospy.wait_for_service(self.emergency_start_topic)
         self.emergency_start = rospy.ServiceProxy(self.emergency_start_topic, Start)
 
+        # Action server for controlling the fingers.
         self.fingersActionTopic = "/jaco_arm_driver/fingers/finger_positions"
         self.fingersClient = actionlib.SimpleActionClient(self.fingersActionTopic,
                                                           SetFingersPositionAction)
         self.fingersClient.wait_for_server()
 
+        # The joystick topic that "commands" this node.
         rospy.Subscriber('/joy', Joy, self.joyCallBack)
 
-        # hack
-        self.joy_axis2_moved = False
-        self.joy_axis5_moved = False
-
-    ## Listen to the flippers state.
     def joyCallBack(self, joy):
-        '''Listen to the joystick state.'''
+        """
+        Joystick state change callback. Do all the command translation and command the real arm.
+        @param joy: The new joystick state.
+        @type joy: sensor_msgs.msg.Joy
+        """
 
-        if joy.buttons[1] == 1:
+        # First of all, check if the emergency stop is not required, and if it is, call the appropriate service.
+        if self.joystick_interface.get_value(joy, 'emergency_stop') == 1:
             self.emergency_stop()
             rospy.loginfo("Arm stopped.")
             return
 
-        if joy.buttons[3] == 1:
+        # Similarly, perform the emergency stop release if needed.
+        if self.joystick_interface.get_value(joy, 'emergency_release'):
             self.emergency_start()
             rospy.loginfo("Arm started.")
             return
 
-        if not self.joy_axis2_moved and joy.axes[2] != 0:
-            self.joy_axis2_moved = True
-
-        if not self.joy_axis5_moved and joy.axes[5] != 0:
-            self.joy_axis5_moved = True
-
+        # The command that's gonna be sent to the arm.
         command = JoystickCommand()
 
-        command.InclineLeftRight = joy.axes[0]
-        command.InclineForwardBackward = -joy.axes[1]
-        if self.joy_axis2_moved:
-            command.Rotate = (joy.axes[2] - 1) / 2
-        if joy.buttons[4] == 1:
-            command.Rotate = 1
-        command.MoveLeftRight = -joy.axes[3]
-        command.MoveForwardBackward = joy.axes[4]
-        if self.joy_axis5_moved:
-            command.PushPull = (joy.axes[5] - 1) / 2
-        if joy.buttons[5] == 1:
-            command.PushPull = 1
+        # Translate the commands to the arm.
+        command.InclineLeftRight = self.joystick_interface.get_value(joy, 'translate_left_right')
+        command.InclineForwardBackward = self.joystick_interface.get_value(joy, 'translate_forward_backward')
+        command.Rotate = self.joystick_interface.get_value(joy, 'translate_up_down')
 
-        if joy.buttons[7] == 1:
+        command.MoveLeftRight = self.joystick_interface.get_value(joy, 'rotate_x')
+        command.MoveForwardBackward = self.joystick_interface.get_value(joy, 'rotate_y')
+        command.PushPull = self.joystick_interface.get_value(joy, 'rotate_wrist')
+
+        if self.joystick_interface.get_value(joy, 'home_arm') == 1:
             command.ButtonValue[2] = 1
 
+        # Send the built command to the real arm.
         self.joystick_pub.publish(command)
 
+        # Fingers are controlled using the action server. The action server only accepts target finger positions,
+        # so we only need to set either 0 (min) or 65 (max) target values and stop execution when the control is
+        # released.
         fingersTargetPosition = None
-        if joy.axes[7] < -0.1 or joy.buttons[0] == 1:
+        fingersJoyValue = self.joystick_interface.get_value(joy, 'fingers_open_close')
+        if fingersJoyValue < -0.1:
             fingersTargetPosition = 65
-        if joy.axes[7] > 0.1 or joy.buttons[2] == 1:
+        elif fingersJoyValue > 0.1:
             fingersTargetPosition = 0
 
         if fingersTargetPosition is not None:
+            # Send the request to the real arm.
             goal = SetFingersPositionGoal()
             goal.fingers.finger1 = float(fingersTargetPosition)
             goal.fingers.finger2 = float(fingersTargetPosition)
@@ -97,11 +113,11 @@ class JacoTeleopJoy(object):
 
             self.fingersClient.send_goal(goal)
         else:
+            # The control has been released, so immediately stop executing the action.
             self.fingersClient.cancel_all_goals()
 
-## Create a ROS node and instantiate the JacoTeleopJoy class.
 def main():
-    '''Create a ROS node and instantiate the JacoTeleopJoy class.'''
+    """Create a ROS node and instantiate the JacoTeleopJoy class."""
     try:
         rospy.init_node('jaco_teleop_joy')
         jtj = JacoTeleopJoy()

--- a/jaco_teleop/nodes/jaco_teleop_joy.py
+++ b/jaco_teleop/nodes/jaco_teleop_joy.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# # @file
+# Joystick teleoperation module for the Kinova Jaco arm
+#
+import roslib
+
+roslib.load_manifest('jaco_teleop')
+import rospy
+import actionlib
+from sensor_msgs.msg import Joy
+
+from jaco_msgs.msg import JoystickCommand, SetFingersPositionAction, SetFingersPositionGoal
+from jaco_msgs.srv import Start, Stop;
+
+from time import sleep
+
+## Joystick teleoperation class
+class JacoTeleopJoy(object):
+    '''Joystick teleoperation interface.
+	'''
+
+    ## Instantiate a JacoTeleopJoy object
+    def __init__(self):
+        self.joystick_topic = "/jaco_arm_driver/in/joystick_command"
+        self.joystick_pub = rospy.Publisher(self.joystick_topic, JoystickCommand, queue_size=10)
+
+        self.emergency_stop_topic = "/jaco_arm_driver/in/stop"
+        rospy.wait_for_service(self.emergency_stop_topic)
+        self.emergency_stop = rospy.ServiceProxy(self.emergency_stop_topic, Stop)
+
+        self.emergency_start_topic = "/jaco_arm_driver/in/start"
+        rospy.wait_for_service(self.emergency_start_topic)
+        self.emergency_start = rospy.ServiceProxy(self.emergency_start_topic, Start)
+
+        self.fingersActionTopic = "/jaco_arm_driver/fingers/finger_positions"
+        self.fingersClient = actionlib.SimpleActionClient(self.fingersActionTopic,
+                                                          SetFingersPositionAction)
+        self.fingersClient.wait_for_server()
+
+        rospy.Subscriber('/joy', Joy, self.joyCallBack)
+
+        # hack
+        self.joy_axis2_moved = False
+        self.joy_axis5_moved = False
+
+    ## Listen to the flippers state.
+    def joyCallBack(self, joy):
+        '''Listen to the joystick state.'''
+
+        if joy.buttons[1] == 1:
+            self.emergency_stop()
+            rospy.loginfo("Arm stopped.")
+            return
+
+        if joy.buttons[3] == 1:
+            self.emergency_start()
+            rospy.loginfo("Arm started.")
+            return
+
+        if not self.joy_axis2_moved and joy.axes[2] != 0:
+            self.joy_axis2_moved = True
+
+        if not self.joy_axis5_moved and joy.axes[5] != 0:
+            self.joy_axis5_moved = True
+
+        command = JoystickCommand()
+
+        command.InclineLeftRight = joy.axes[0]
+        command.InclineForwardBackward = -joy.axes[1]
+        if self.joy_axis2_moved:
+            command.Rotate = (joy.axes[2] - 1) / 2
+        if joy.buttons[4] == 1:
+            command.Rotate = 1
+        command.MoveLeftRight = -joy.axes[3]
+        command.MoveForwardBackward = joy.axes[4]
+        if self.joy_axis5_moved:
+            command.PushPull = (joy.axes[5] - 1) / 2
+        if joy.buttons[5] == 1:
+            command.PushPull = 1
+
+        if joy.buttons[7] == 1:
+            command.ButtonValue[2] = 1
+
+        self.joystick_pub.publish(command)
+
+        fingersTargetPosition = None
+        if joy.axes[7] < -0.1 or joy.buttons[0] == 1:
+            fingersTargetPosition = 65
+        if joy.axes[7] > 0.1 or joy.buttons[2] == 1:
+            fingersTargetPosition = 0
+
+        if fingersTargetPosition is not None:
+            goal = SetFingersPositionGoal()
+            goal.fingers.finger1 = float(fingersTargetPosition)
+            goal.fingers.finger2 = float(fingersTargetPosition)
+            goal.fingers.finger3 = float(fingersTargetPosition)
+
+            self.fingersClient.send_goal(goal)
+        else:
+            self.fingersClient.cancel_all_goals()
+
+## Create a ROS node and instantiate the JacoTeleopJoy class.
+def main():
+    '''Create a ROS node and instantiate the JacoTeleopJoy class.'''
+    try:
+        rospy.init_node('jaco_teleop_joy')
+        jtj = JacoTeleopJoy()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/jaco_teleop/package.xml
+++ b/jaco_teleop/package.xml
@@ -15,7 +15,7 @@
     <p>This node simply remaps gamepad commands to the Jaco dedicated controller commands. Using the default gamepad config, the gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the &quot;front panel&quot; (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set (when using the default gamepad config).</p>
 
     <h2>Default controls remapping (Logitech F710):</h2>
-    <code><xmp>Thanks to RIVeR-Lab/wpi_jaco for base of this image
+    <code><xmp><![CDATA[Thanks to RIVeR-Lab/wpi_jaco for base of this image
 
                Controls                
     up/down                 rotate wrist
@@ -36,7 +36,7 @@ Buttons:
   (1) Fingers open
   (2) Fingers close
   (3) Emergency stop                    
-  (4) Emergency release</xmp></code>
+  (4) Emergency release]]></xmp></code>
 
     <h2>Contributing</h2>
     <p>If you write your own YAML config for another controller, feel free to fork this repo and place a merge request.</p>	

--- a/jaco_teleop/package.xml
+++ b/jaco_teleop/package.xml
@@ -3,40 +3,43 @@
   <name>jaco_teleop</name>
   <version>1.0.0</version>
   <description>
-	<p>Teleoperation support for Jaco arm.</p>
-	<p>Launching jaco_teleop.launch assumes that jaco_driver/jaco_arm.launch has already been running.</p>
-	<p>This node simply remaps gamepad commands to the Jaco dedicated controller commands. The gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the "front panel" (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set.</p>
-	<p>
-		Controls remapping:
-		<dl>
-			<dt>Left joystick</dt>
-			<dd>Translation x/y</dd>
+    <h1>Teleoperation support for Jaco arm.</h1>
 
-			<dt>Right joystick</dt>
-			<dd>Rotation x/y</dd>
+    <p>To run the teleoperation node, type simply</p>
+    <pre><code>roslaunch jaco_teleop jaco_teleop.launch</code></pre>
+    <p>or </p>
+    <pre><code>roslaunch jaco_teleop jaco_teleop.launch joystick_type:=xbox_360</code></pre>
+    <p>if you have the appropriate YAML config file in the <code>config</code> directory (in this example <code>config/xbox_360.yaml</code>). </p>
 
-			<dt>Left back buttons (one analog, one digital)</dt>
-			<dd>Translation z</dd>
+    <p>Launching <code>jaco_teleop.launch</code> assumes that <code>jaco_driver/jaco_arm.launch</code> has already been running.</p>
+    <p>This node simply remaps gamepad commands to the Jaco dedicated controller commands. Using the default gamepad config, the gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the &quot;front panel&quot; (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set (when using the default gamepad config).</p>
 
-			<dt>Right back buttons (one analog, one digital)</dt>
-			<dd>Rotation theta (wrist joint)</dd>
+    <h2>Default controls remapping (Logitech F710):</h2>
+    <code><xmp>Thanks to RIVeR-Lab/wpi_jaco for base of this image
 
-			<dt>Left cross up/down</dt>
-			<dd>Open/close all fingers</dd>
+               Controls                
+    up/down                 rotate wrist
+   ________                 __________    
+  /fin.open\_______________/          \   
+ |   _| |_    < >  < home >     (4)    |  
+ |  |_   _|   < >    < >     (1)   (3) |  
+ |    |_|    ___       ___      (2)    |  
+ | fin.close/   \     /   \            |  
+ |          \___/     \___/            |  
+ |       x/y trans  rotate x/y         |  
+ |        _______/---\_______          |  
+ |       |                    \        |  
+  \      /                     \      /   
+   \____/                       \____/    
 
-			<dt>A (2), X (1) buttons</dt>
-			<dd>Open/close all fingers</dd>
+Buttons:                               
+  (1) Fingers open
+  (2) Fingers close
+  (3) Emergency stop                    
+  (4) Emergency release</xmp></code>
 
-			<dt>B (3)</dt>
-			<dd>Emergency stop (when holding)</dd>
-
-			<dt>Y (4)</dt>
-			<dd>Release emergency stop</dd>
-
-			<dt>Start button</dt>
-			<dd>Home arm/go to retreat (it's always needed to home the arm before you can control it)</dd>
-		</dl>	
-	</p>
+    <h2>Contributing</h2>
+    <p>If you write your own YAML config for another controller, feel free to fork this repo and place a merge request.</p>	
   </description>
 
   <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
@@ -45,17 +48,13 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>actionlib</build_depend>
-  <build_depend>geometry_msgs</build_depend>
   <build_depend>jaco_msgs</build_depend>
   <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <run_depend>actionlib</run_depend>
-  <run_depend>geometry_msgs</run_depend>
   <run_depend>joy</run_depend>
   <run_depend>jaco_msgs</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>topic_tools</run_depend>

--- a/jaco_teleop/package.xml
+++ b/jaco_teleop/package.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<package>
+  <name>jaco_teleop</name>
+  <version>1.0.0</version>
+  <description>
+	<p>Teleoperation support for Jaco arm.</p>
+	<p>Launching jaco_teleop.launch assumes that jaco_driver/jaco_arm.launch has already been running.</p>
+	<p>This node simply remaps gamepad commands to the Jaco dedicated controller commands. The gamepad is assumed to have two analog joysticks (they produce float values), 4 digital buttons (their output is 0/1) on the left (the cross), 4 digital buttons on the right (ABCD or 1234), two digital buttons on the back side, two analog buttons on the back side, and 4 digital buttons on the "front panel" (Start, Back, Mode, Vibration). Some joysticks can be switched to two modes - in one of them, all 4 back buttons are digital, and in the other one, two of the back buttons are analog. This node needs the analog mode to be set.</p>
+	<p>
+		Controls remapping:
+		<dl>
+			<dt>Left joystick</dt>
+			<dd>Translation x/y</dd>
+
+			<dt>Right joystick</dt>
+			<dd>Rotation x/y</dd>
+
+			<dt>Left back buttons (one analog, one digital)</dt>
+			<dd>Translation z</dd>
+
+			<dt>Right back buttons (one analog, one digital)</dt>
+			<dd>Rotation theta (wrist joint)</dd>
+
+			<dt>Left cross up/down</dt>
+			<dd>Open/close all fingers</dd>
+
+			<dt>A (2), X (1) buttons</dt>
+			<dd>Open/close all fingers</dd>
+
+			<dt>B (3)</dt>
+			<dd>Emergency stop (when holding)</dd>
+
+			<dt>Y (4)</dt>
+			<dd>Release emergency stop</dd>
+
+			<dt>Start button</dt>
+			<dd>Home arm/go to retreat (it's always needed to home the arm before you can control it)</dd>
+		</dl>	
+	</p>
+  </description>
+
+  <maintainer email="peckama2@fel.cvut.cz">Martin Pecka</maintainer>
+  <license>BSD</license>
+  <author email="peckama2@fel.cvut.cz">Martin Pecka</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>jaco_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>joy</run_depend>
+  <run_depend>jaco_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>topic_tools</run_depend>
+
+
+  <export>
+  </export>
+</package>

--- a/jaco_teleop/setup.py
+++ b/jaco_teleop/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['jaco_teleop'],
+    package_dir={'': 'src'}
+)
+
+setup(**d)

--- a/jaco_teleop/src/jaco_teleop/joystick_interface.py
+++ b/jaco_teleop/src/jaco_teleop/joystick_interface.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+
+from sensor_msgs.msg import Joy
+
+class JoystickInterface(object):
+    """
+    Joystick abstraction layer that allows to specify multiple buttons/axes per single functionality.
+
+    In the constructor you specify the "configuration" of the joystick you want to use, which comprises of
+    functionalities and button/axis assignments for each functionality. The functionalities are the keys of 
+    the config dictionary. Every key has a list assigned to it, in which are listed all buttons/axes that
+    control that functionality (in the order of precedence).
+
+    When correctly set up, you are expected to periodically call get_value() to ask for values for the
+    functionalities. Using this library, you can "remap" any joystick hardware values to any desired
+    "functionality value range", and in your code you then just cleanly ask for the values of your 
+    functionalities. You can also "mix" two (or more) buttons/axes into one functionality.
+
+    See config/readme.yaml for detailed description of the available options. Writing and loading a YAML file
+    is also considered to be the easiest way to get the config dictionary you have to pass to the constructor 
+    (e.g. by loading the YAML file into a dictionary).
+    """
+
+    def __init__(self, config):
+        """
+        Set up the interface using the given joystick configuration.
+        @param config: The configuration of the joystick. See config/readme.yaml for all available options.
+        @type config: dict
+        """
+        self.config = config
+
+        # This maps the "types" from config to functions to process the values. We only have types "button" and "axis"
+        # in sensor_msgs.msg.Joy, but be prepared for extension :) Feel free to add to this list from a subclass.
+        self.get_value_functions = {'button': self.get_button_value, 'axis': self.get_axis_value}
+
+        # If the config contains key dead_man, tell the class we want to use the dead man's button.
+        self.dead_man = ('dead_man' in config) and (len(config['dead_man']) > 0)
+
+        # This is a workaround for axis keys that publish other than neutral value before the axis is moved for
+        # the first time. This is e.g. the case of Logitech F710 back side axes in XInput mode.
+        self.startup_block_passed = {}
+
+    def get_value(self, joy, key):
+        """
+        Return the value for a specified config key for the given joystick state.
+        @param joy: The state of the joystick to compute the value from.
+        @type joy: sensor_msgs.msg.Joy
+        @param key: The config key to get value for. It has to be a key from the config passed to constructor.
+        @type key: string
+        @rtype: object
+        """
+        if not key in self.config:
+            raise ValueError("Key " + key + " not found in joy interface config.")
+
+        # If there is a dead man's button specified, check, if it is pressed. If not, just return the neutral value.
+
+        if self.dead_man and key != 'dead_man':
+            dead_man_neutral = self.get_neutral_value_for_key('dead_man')
+            if self.get_value(joy, 'dead_man') == dead_man_neutral:
+                return self.get_neutral_value_for_key(key)
+
+        # Iterate over all the buttons/axes related to the given config key. The first one which gives a non-neutral
+        # value will be considered as pressed. All other buttons/axes are assumed to give neutral values.
+        for control in self.config[key]:
+            if not 'type' in control:
+                raise ValueError("Type not specified for a control definition for key " + key)
+
+            control_type = control['type']
+            if control_type in self.get_value_functions:
+                # Extract the button's value.
+                result = self.get_value_functions[control_type](joy, control)
+
+                neutral_value = self.get_value_or_default(control, 'neutral_value', 0)
+
+                # Only return if we got a non-neutral value. Otherwise give a chance to the other butons defined for
+                # this config key.
+                if result != neutral_value:
+                    return result
+            else:
+                raise ValueError("Type " + control_type + " is unknown.")
+
+        # If all defined keys return neutral values (nothing is pressed), return the neutral value.
+        return self.get_neutral_value_for_key(key)
+
+    def get_neutral_value_for_key(self, key):
+        """
+        Return the value that is considered neutral for the given config key.
+        @param key: The config key to get neutral value for.
+        @type key: string
+        @rtype: object
+        """
+        # When no buttons are defined for the key, return zero. It could also raise an exception.
+        if len(self.config[key]) == 0:
+            return 0
+
+        # Otherwise return the neutral value specified for the first button.
+        control = self.config[key][0]
+        return self.get_value_or_default(control, 'neutral_value', 0)
+
+    def get_button_value(self, joy, control):
+        """
+        Value getter for the "button" type. Reads joy.buttons.
+        @param joy: The current joystick state to get value for.
+        @type joy: sensor_msgs.msg.Joy
+        @param control: Specifictaion of the button parameters. See config/readme.yaml for all possible parameters.
+        @type control: dict
+        @rtype: object
+        """
+        button_state = joy.buttons[control['id']]
+
+        if button_state == 1:
+            return self.get_value_or_default(control, 'on_value', 1)
+        else:
+            return self.get_value_or_default(control, 'off_value', 0)
+
+    def get_axis_value(self, joy, control):
+        """
+        Value getter for the "axis" type. Reads joy.axes.
+        @param joy: The current joystick state to get value for.
+        @type joy: sensor_msgs.msg.Joy
+        @param control: Specifictaion of the axis parameters. See config/readme.yaml for all possible parameters.
+        @type control: dict
+        @rtype: object
+        """
+        # The value provided from ROS.
+        hw_value = joy.axes[control['id']]
+
+        ###
+        # STARTUP VALUE WORKAROUND START
+        ###
+
+        # None means there is no need to apply the startup value workaround. See self.startup_block_passed.
+        startup_block_value = self.get_value_or_default(control, 'startup_block_value', None)
+
+        # If we have to use the startup value workaround, then continue returning the neutral value as long as the
+        # value hasn't changed; once we receive any other value, we remember in self.startup_block_passed that this
+        # axis is now "clean" and we can trust its values.
+        if startup_block_value is not None and control['id'] not in self.startup_block_passed and hw_value == startup_block_value:
+            return self.get_value_or_default(control, 'neutral_value', 0)
+
+        # Either we don't need the workaround or the axis value is different from the startup one, which means 
+        # we want to remember this axis as "clean".
+        self.startup_block_passed[control['id']] = True
+
+        ###
+        # STARTUP VALUE WORKAROUND END
+        ###
+
+        # Mimimum value from the joystick.
+        hw_min = float(self.get_value_or_default(control, 'hw_min', -1))
+        # Maximum value from the joystick.
+        hw_max = float(self.get_value_or_default(control, 'hw_max', 1))
+        # Minimum output value.
+        remap_min = float(self.get_value_or_default(control, 'remap_min', -1))
+        # Maximum output value.
+        remap_max = float(self.get_value_or_default(control, 'remap_max', 1))
+        # If True, the joystick min maps to output max and vice versa.
+        invert = self.get_value_or_default(control, 'invert', False)
+
+        hw_range = hw_max - hw_min
+        remap_range = remap_max - remap_min
+        
+        if invert:
+            value = hw_max - hw_value
+        else:
+            value = hw_value - hw_min
+
+        # Scale and shift the joystick value to the output range.
+        return value * remap_range / hw_range + remap_min
+
+
+    def get_value_or_default(self, control, key, default):
+        """
+        If "key" is a key in "control", return its associated value. Otherwise return "default".
+        @param control: The dictionary to get values from.
+        @type control: dict
+        @param key: The key to search for in "control".
+        @type key: string
+        @param default: The value to return if "key" is not a key in "control".
+        @type default: object
+        @rtype: object
+        """
+        if key in control:
+            return control[key]
+        else:
+            return default
+
+    def get_description(self):
+        """
+        Return the description of the loaded configuration, and optionally provide ASCII-art drawing of the functions.
+        @rtype: string
+        """
+        if 'description' in self.config and self.config['description'] != '':
+            return self.config['description']
+        else:
+            return "The current joystick config has no description specified. Please, specify key 'description' in the config to show the description message (or drawing) here."


### PR DESCRIPTION
Hello, we've implemented support for teleoperating Jaco using a gamepad (published to ROS topic /joy ). 

It basically just translates /joy messages to jaco_msgs/JoystickCommand, and it contains powerful options for configuring the joystick button mapping.
