### PR TITLE
Install target patch : update install target of kinova_driver

### DIFF
--- a/kinova_bringup/CMakeLists.txt
+++ b/kinova_bringup/CMakeLists.txt
@@ -136,11 +136,10 @@ catkin_package(
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+install(FILES
+  launch/kinova_robot.launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 #############
 ## Testing ##

--- a/kinova_driver/CMakeLists.txt
+++ b/kinova_driver/CMakeLists.txt
@@ -124,10 +124,11 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(FILES
-  launch/jaco_arm.launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
 
 #############
 ## Testing ##

--- a/kinova_driver/CMakeLists.txt
+++ b/kinova_driver/CMakeLists.txt
@@ -96,13 +96,6 @@ target_link_libraries(kinova_interactive_control ${catkin_LIBRARIES} kinova_driv
 ## Install ##
 #############
 
-install(PROGRAMS
-  test/angle_action_client.py
-  test/finger_action_client.py
-  test/pose_action_client.py
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
 # Copy over Kinova .so binary blobs to /usr/lib
 install(FILES
   lib/${CMAKE_LIBRARY_ARCHITECTURE}/Kinova.API.CommLayerUbuntu.so


### PR DESCRIPTION
Hello Kinova !

I just checked the package and saw that the "kinova_driver" package still contains : 
1. The install target for the test script in python which are now in the "kinova_demo" package.
2. The install target for the launch file which is now in the "kinova_bringup" package.
I removed the both

Also the "kinova_bringup" package was missing the install target for the launch file "kinova_robot.launch".

It should be good now :)
