### PR TITLE
Moveit compilation fix

### DIFF
--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,13 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+
+    urdf::JointConstSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointConstSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointConstSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   // Note that we are just planning, not asking move_group 
   // to actually move the robot.
   moveit::planning_interface::MoveGroup::Plan my_plan;
-  bool success = group.plan(my_plan);
+  bool success = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
 
   ROS_INFO("Visualizing plan 1 (pose goal) %s",success?"":"FAILED");    
   /* Sleep to give Rviz time to visualize the plan. */
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
   // space goal and visualize the plan.
   group_variable_values[5] = -1.0;
   group.setJointValueTarget(group_variable_values);
-  success = group.plan(my_plan);
+  success = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
 
   ROS_INFO("Visualizing plan 2 (joint space goal) %s",success?"":"FAILED");
   /* Sleep to give Rviz time to visualize the plan. */
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
   // Now we will plan to the earlier pose target from the new 
   // start state that we have just created.
   group.setPoseTarget(target_pose1);
-  success = group.plan(my_plan);
+  success = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
 
   ROS_INFO("Visualizing plan 3 (constraints) %s",success?"":"FAILED");
   /* Sleep to give Rviz time to visualize the plan. */
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
   // Now when we plan a trajectory it will avoid the obstacle
   group.setStartState(*group.getCurrentState());
   group.setPoseTarget(target_pose1);
-  success = group.plan(my_plan);
+  success = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
 
   ROS_INFO("Visualizing plan 5 (pose goal move around box) %s",
     success?"":"FAILED");

--- a/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
@@ -655,7 +655,7 @@ void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
             plan_time = 20+count*10;
             ROS_INFO("Setting plan time to %f sec", plan_time);
             group.setPlanningTime(plan_time);
-            result_ = group.plan(my_plan);
+            result_ = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
             std::cout << "at attemp: " << count << std::endl;
             ros::WallDuration(0.1).sleep();
         }

--- a/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
@@ -659,7 +659,7 @@ void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
             plan_time = 20+count*10;
             ROS_INFO("Setting plan time to %f sec", plan_time);
             group.setPlanningTime(plan_time);
-            result_ = group.plan(my_plan);
+            result_ = group.plan(my_plan) == moveit::planning_interface::MoveItErrorCode::SUCCESS;
             std::cout << "at attemp: " << count << std::endl;
             ros::WallDuration(0.1).sleep();
         }


### PR DESCRIPTION
Compilation of master branch fails with recent moveit versions. This PR substitutes
``` boost::shared_ptr<urdf::Link>``` with ``` link = robot_model.getLink(getTipFrame());```
Furthermore, the return type of ```MoveGroup.plan()``` has been altered to return an error code instead of a boolean.