### PR TITLE
fix errors on ros melodic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ kvh_driver/src/kvh_driver/
 
 # Python
 *.pyc
+
+# VS code config
+.vscode/

--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -23,7 +23,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <box size = "0 0 0"/>
+        <box size = "0.001 0.001 0.001"/>
       </geometry>
     <!--<material name="Black" /> -->
     </visual>
@@ -31,7 +31,7 @@
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <box size = "0 0 0"/> 
+        <box size = "0.001 0.001 0.001"/> 
       </geometry>
     </collision>     
   </link>

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -81,12 +81,12 @@
         <link name="${link_name}">
             <visual>
                 <geometry>
-                    <box size = "0 0 0"/>
+                    <box size = "0.001 0.001 0.001"/>
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <box size = "0 0 0"/>
+                    <box size = "0.001 0.001 0.001"/>
                 </geometry>
             </collision>
         </link>

--- a/kinova_gazebo/launch/robot_launch.launch
+++ b/kinova_gazebo/launch/robot_launch.launch
@@ -43,6 +43,6 @@
     <arg name="kinova_robotType" value="$(arg kinova_robotName)"/>
   </include> 
   -->
-
+	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find urdf_tutorial)/urdf.rviz" />
 </launch>
 

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,13 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    //boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    auto joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/package.xml
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/package.xml
@@ -41,9 +41,11 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>pluginlib</build_depend>
+
   <run_depend>moveit_core</run_depend>
   <run_depend>liblapack-dev</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf_conversions</run_depend>
   <run_depend>pluginlib</run_depend>
+
 </package>

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/kinova_arm_moveit_demo/CMakeLists.txt
+++ b/kinova_moveit/kinova_arm_moveit_demo/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED
              pluginlib
              cmake_modules
              geometric_shapes
+             eigen_conversions
 )
 
 find_package(Boost REQUIRED system filesystem date_time thread)
@@ -24,6 +25,7 @@ catkin_package(
     moveit_core
     moveit_ros_planning_interface
     interactive_markers
+    eigen_conversions
 )
 find_package(Eigen REQUIRED)
 

--- a/kinova_moveit/kinova_arm_moveit_demo/include/pick_place.h
+++ b/kinova_moveit/kinova_arm_moveit_demo/include/pick_place.h
@@ -74,7 +74,7 @@ namespace kinova
         bool use_KinovaInK_;
 
         // check some process if success.
-        bool result_;
+        moveit::planning_interface::MoveItErrorCode result_;
         // wait for user input to continue: cin >> pause_;
         std::string pause_;
         std::string robot_type_;

--- a/kinova_moveit/kinova_arm_moveit_demo/include/test_accuracy.h
+++ b/kinova_moveit/kinova_arm_moveit_demo/include/test_accuracy.h
@@ -77,7 +77,7 @@ namespace kinova
         bool use_KinovaInK_;
 
         // check some process if success.
-        bool result_;
+        moveit::planning_interface::MoveItErrorCode result_;
         // wait for user input to continue: cin >> pause_;
         std::string pause_;
         std::string robot_type_;

--- a/kinova_moveit/kinova_arm_moveit_demo/package.xml
+++ b/kinova_moveit/kinova_arm_moveit_demo/package.xml
@@ -18,6 +18,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>kinova_driver</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>pluginlib</run_depend>
   <run_depend>moveit_core</run_depend>
@@ -29,5 +30,6 @@
   <run_depend>pr2_moveit_config</run_depend>
   <run_depend>pr2_moveit_plugins</run_depend>
   <run_depend>kinova_driver</run_depend>
+  <run_depend>eigen_conversions</run_depend>
 
 </package>

--- a/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   // Note that we are just planning, not asking move_group 
   // to actually move the robot.
   moveit::planning_interface::MoveGroup::Plan my_plan;
-  bool success = group.plan(my_plan);
+  auto success = group.plan(my_plan);
 
   ROS_INFO("Visualizing plan 1 (pose goal) %s",success?"":"FAILED");    
   /* Sleep to give Rviz time to visualize the plan. */


### PR DESCRIPTION
1. gazebo 7 will crash due to size="0 0 0 "
2. moveit now uses std::shared_ptr
3. add eigen_conversions to build files
4. fix type of group.plan()