### PR TITLE
Fixing compilation error on ros kinectic

### DIFF
--- a/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   // Note that we are just planning, not asking move_group 
   // to actually move the robot.
   moveit::planning_interface::MoveGroup::Plan my_plan;
-  bool success = group.plan(my_plan);
+  bool success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
 
   ROS_INFO("Visualizing plan 1 (pose goal) %s",success?"":"FAILED");    
   /* Sleep to give Rviz time to visualize the plan. */
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
   // space goal and visualize the plan.
   group_variable_values[5] = -1.0;
   group.setJointValueTarget(group_variable_values);
-  success = group.plan(my_plan);
+  success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
 
   ROS_INFO("Visualizing plan 2 (joint space goal) %s",success?"":"FAILED");
   /* Sleep to give Rviz time to visualize the plan. */
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
   // Now we will plan to the earlier pose target from the new 
   // start state that we have just created.
   group.setPoseTarget(target_pose1);
-  success = group.plan(my_plan);
+  success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
 
   ROS_INFO("Visualizing plan 3 (constraints) %s",success?"":"FAILED");
   /* Sleep to give Rviz time to visualize the plan. */
@@ -268,7 +268,7 @@ int main(int argc, char **argv)
   // Now when we plan a trajectory it will avoid the obstacle
   group.setStartState(*group.getCurrentState());
   group.setPoseTarget(target_pose1);
-  success = group.plan(my_plan);
+  success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
 
   ROS_INFO("Visualizing plan 5 (pose goal move around box) %s",
     success?"":"FAILED");

--- a/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
@@ -655,7 +655,7 @@ void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
             plan_time = 20+count*10;
             ROS_INFO("Setting plan time to %f sec", plan_time);
             group.setPlanningTime(plan_time);
-            result_ = group.plan(my_plan);
+            result_ = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
             std::cout << "at attemp: " << count << std::endl;
             ros::WallDuration(0.1).sleep();
         }

--- a/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
@@ -659,7 +659,7 @@ void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
             plan_time = 20+count*10;
             ROS_INFO("Setting plan time to %f sec", plan_time);
             group.setPlanningTime(plan_time);
-            result_ = group.plan(my_plan);
+            result_ = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
             std::cout << "at attemp: " << count << std::endl;
             ros::WallDuration(0.1).sleep();
         }


### PR DESCRIPTION
Compilation of master branch failed with moveit on ros kinectic. The recent moveit disabled implicit conversation from MoveItErrorCode to Boolean, which caused compilation error here. (refer to https://github.com/ros-planning/moveit/issues/759)

This PR replaced `bool success = group.plan(my_plan);` with `bool success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);`. It has been tested on ros kinectic.