### PR TITLE
Melodic support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ kvh_driver/src/kvh_driver/
 
 # Python
 *.pyc
+
+# VS code config
+.vscode/

--- a/kinova_driver/src/joint_trajectory_action/gripper_command_action_server.cpp
+++ b/kinova_driver/src/joint_trajectory_action/gripper_command_action_server.cpp
@@ -179,7 +179,7 @@ int main(int argc, char** argv)
 
     kinova::GripperCommandActionController gcac(node,robot_name);
 
-    ros::spin();
+    ros::waitForShutdown();
     return 0;
 }
 

--- a/kinova_driver/src/joint_trajectory_action/joint_trajectory_action_server.cpp
+++ b/kinova_driver/src/joint_trajectory_action/joint_trajectory_action_server.cpp
@@ -291,6 +291,6 @@ int main(int argc, char** argv)
 
     kinova::JointTrajectoryActionController jtac(node, robot_name);
 
-    ros::spin();
+    ros::waitForShutdown();
     return 0;
 }

--- a/kinova_gazebo/launch/robot_launch.launch
+++ b/kinova_gazebo/launch/robot_launch.launch
@@ -67,6 +67,6 @@
     <arg name="kinova_robotType" value="$(arg kinova_robotName)"/>
   </include> 
   -->
-
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find urdf_tutorial)/urdf.rviz" />
 </launch>
 

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
@@ -364,8 +364,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    //boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
-    auto joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
@@ -359,7 +359,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2n6s300_ikfast/src/j2n6s300_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,13 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    //boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    auto joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
@@ -359,7 +359,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/j2s7s300_ikfast/src/j2s7s300_robot_arm_ikfast_moveit_plugin.cpp
@@ -364,7 +364,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/package.xml
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/package.xml
@@ -41,9 +41,11 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>pluginlib</build_depend>
+
   <run_depend>moveit_core</run_depend>
   <run_depend>liblapack-dev</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf_conversions</run_depend>
   <run_depend>pluginlib</run_depend>
+
 </package>

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
@@ -359,12 +359,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
@@ -359,7 +359,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  std::shared_ptr<urdf::Link> link = std::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());

--- a/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
+++ b/kinova_moveit/inverse_kinematics_plugins/ikfast/m1n6s300_ikfast/src/m1n6s300_mico_arm_ikfast_moveit_plugin.cpp
@@ -364,7 +364,7 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    std::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)

--- a/kinova_moveit/kinova_arm_moveit_demo/CMakeLists.txt
+++ b/kinova_moveit/kinova_arm_moveit_demo/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED
              pluginlib
              cmake_modules
              geometric_shapes
+             eigen_conversions
 )
 
 find_package(Boost REQUIRED system filesystem date_time thread)
@@ -24,6 +25,7 @@ catkin_package(
     moveit_core
     moveit_ros_planning_interface
     interactive_markers
+    eigen_conversions
 )
 find_package(Eigen REQUIRED)
 

--- a/kinova_moveit/kinova_arm_moveit_demo/include/pick_place.h
+++ b/kinova_moveit/kinova_arm_moveit_demo/include/pick_place.h
@@ -12,7 +12,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/conversions.h>
 
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
@@ -46,8 +46,8 @@ namespace kinova
         // open&close fingers: gripper_group_.plan not alway have a solution
         actionlib::SimpleActionClient<kinova_msgs::SetFingersPositionAction>* finger_client_;
 
-        moveit::planning_interface::MoveGroup* group_;
-        moveit::planning_interface::MoveGroup* gripper_group_;
+        moveit::planning_interface::MoveGroupInterface* group_;
+        moveit::planning_interface::MoveGroupInterface* gripper_group_;
         robot_model::RobotModelPtr robot_model_;
 //        robot_state::RobotStatePtr robot_state_;
 
@@ -122,7 +122,7 @@ namespace kinova
         // TODO: use Kinova inverse kinematic solution instead of from ROS.
         void getInvK(geometry_msgs::Pose &eef_pose, std::vector<double> &joint_value);
         void check_collision();
-        void evaluate_plan(moveit::planning_interface::MoveGroup &group);
+        void evaluate_plan(moveit::planning_interface::MoveGroupInterface &group);
         bool gripper_action(double gripper_rad);
     };
 }

--- a/kinova_moveit/kinova_arm_moveit_demo/include/test_accuracy.h
+++ b/kinova_moveit/kinova_arm_moveit_demo/include/test_accuracy.h
@@ -12,7 +12,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <moveit/robot_state/conversions.h>
 
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_interface/planning_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
@@ -49,8 +49,8 @@ namespace kinova
         // open&close fingers: gripper_group_.plan not alway have a solution
         actionlib::SimpleActionClient<kinova_msgs::SetFingersPositionAction>* finger_client_;
 
-        moveit::planning_interface::MoveGroup* group_;
-        moveit::planning_interface::MoveGroup* gripper_group_;
+        moveit::planning_interface::MoveGroupInterface* group_;
+        moveit::planning_interface::MoveGroupInterface* gripper_group_;
         robot_model::RobotModelPtr robot_model_;
 //        robot_state::RobotStatePtr robot_state_;
 
@@ -127,7 +127,7 @@ namespace kinova
         // TODO: use Kinova inverse kinematic solution instead of from ROS.
         void getInvK(geometry_msgs::Pose &eef_pose, std::vector<double> &joint_value);
         void check_collision();
-        void evaluate_plan(moveit::planning_interface::MoveGroup &group);
+        void evaluate_plan(moveit::planning_interface::MoveGroupInterface &group);
         bool gripper_action(double gripper_rad);
         void evaluate_move_accuracy();
     };

--- a/kinova_moveit/kinova_arm_moveit_demo/package.xml
+++ b/kinova_moveit/kinova_arm_moveit_demo/package.xml
@@ -18,6 +18,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>geometric_shapes</build_depend>
   <build_depend>kinova_driver</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>pluginlib</run_depend>
   <run_depend>moveit_core</run_depend>
@@ -29,5 +30,6 @@
   <run_depend>pr2_moveit_config</run_depend>
   <run_depend>pr2_moveit_plugins</run_depend>
   <run_depend>kinova_driver</run_depend>
+  <run_depend>eigen_conversions</run_depend>
 
 </package>

--- a/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/motion_plan.cpp
@@ -1,4 +1,4 @@
-#include <moveit/move_group_interface/move_group.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
 
 #include <moveit_msgs/DisplayRobotState.h>
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
   // The :move_group_interface:`MoveGroup` class can be easily 
   // setup using just the name
   // of the group you would like to control and plan for.
-  moveit::planning_interface::MoveGroup group("arm");
+  moveit::planning_interface::MoveGroupInterface group("arm");
 
   // We will use the :planning_scene_interface:`PlanningSceneInterface`
   // class to deal directly with the world.
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
   // and visualize it.
   // Note that we are just planning, not asking move_group 
   // to actually move the robot.
-  moveit::planning_interface::MoveGroup::Plan my_plan;
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
   bool success = (group.plan(my_plan) == moveit_msgs::MoveItErrorCodes::SUCCESS);
 
   ROS_INFO("Visualizing plan 1 (pose goal) %s",success?"":"FAILED");    

--- a/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/pick_place.cpp
@@ -57,8 +57,8 @@ PickPlace::PickPlace(ros::NodeHandle &nh):
 //    robot_state::RobotState& robot_state = planning_scene_->getCurrentStateNonConst();
 //    const robot_state::JointModelGroup *joint_model_group = robot_state.getJointModelGroup("arm");
 
-    group_ = new moveit::planning_interface::MoveGroup("arm");
-    gripper_group_ = new moveit::planning_interface::MoveGroup("gripper");
+    group_ = new moveit::planning_interface::MoveGroupInterface("arm");
+    gripper_group_ = new moveit::planning_interface::MoveGroupInterface("gripper");
 
     group_->setEndEffectorLink(robot_type_ + "_end_effector");
 
@@ -634,12 +634,12 @@ void PickPlace::check_constrain()
     }
 }
 
-void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
+void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroupInterface &group)
 {
     bool replan = true;
     int count = 0;
 
-    moveit::planning_interface::MoveGroup::Plan my_plan;
+    moveit::planning_interface::MoveGroupInterface::Plan my_plan;
 
     while (replan == true && ros::ok())
     {

--- a/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
+++ b/kinova_moveit/kinova_arm_moveit_demo/src/test_accuracy.cpp
@@ -59,8 +59,8 @@ PickPlace::PickPlace(ros::NodeHandle &nh):
 //    robot_state::RobotState& robot_state = planning_scene_->getCurrentStateNonConst();
 //    const robot_state::JointModelGroup *joint_model_group = robot_state.getJointModelGroup("arm");
 
-    group_ = new moveit::planning_interface::MoveGroup("arm");
-    gripper_group_ = new moveit::planning_interface::MoveGroup("gripper");
+    group_ = new moveit::planning_interface::MoveGroupInterface("arm");
+    gripper_group_ = new moveit::planning_interface::MoveGroupInterface("gripper");
 
     group_->setEndEffectorLink(robot_type_ + "_end_effector");
 
@@ -638,12 +638,12 @@ void PickPlace::check_constrain()
     }
 }
 
-void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroup &group)
+void PickPlace::evaluate_plan(moveit::planning_interface::MoveGroupInterface &group)
 {
     bool replan = true;
     int count = 0;
 
-    moveit::planning_interface::MoveGroup::Plan my_plan;
+    moveit::planning_interface::MoveGroupInterface::Plan my_plan;
 
     while (replan == true && ros::ok())
     {

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/config/j2n6s300.srdf
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/config/j2n6s300.srdf
@@ -46,12 +46,12 @@
     <group_state name="Open" group="gripper">
         <joint name="j2n6s300_joint_finger_1" value="0.2" />
         <joint name="j2n6s300_joint_finger_2" value="0.2" />
-        <joint name="j2n6s300_joint_finger_3" value="0.2" />        
+        <joint name="j2n6s300_joint_finger_3" value="0.2" />
     </group_state>
     <group_state name="Close" group="gripper">
         <joint name="j2n6s300_joint_finger_1" value="1.2" />
         <joint name="j2n6s300_joint_finger_2" value="1.2" />
-        <joint name="j2n6s300_joint_finger_3" value="1.2" />       
+        <joint name="j2n6s300_joint_finger_3" value="1.2" />
     </group_state>
     <group_state name="Vertical" group="arm">
         <joint name="j2n6s300_joint_1" value="3.1415" />

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group.launch
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group.launch
@@ -48,7 +48,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group_j2n6s300.launch
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group_j2n6s300.launch
@@ -51,7 +51,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/move_group_j2s6s300.launch
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/move_group_j2s6s300.launch
@@ -51,7 +51,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group.launch
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group.launch
@@ -48,7 +48,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group_j2s7s300.launch
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group_j2s7s300.launch
@@ -49,7 +49,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/config/m1n6s300.srdf
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/config/m1n6s300.srdf
@@ -41,12 +41,12 @@
     <group_state name="Open" group="gripper">
         <joint name="m1n6s300_joint_finger_1" value="0.2" />
         <joint name="m1n6s300_joint_finger_2" value="0.2" />
-        <joint name="m1n6s300_joint_finger_3" value="0.2" />      
+        <joint name="m1n6s300_joint_finger_3" value="0.2" />
     </group_state>
     <group_state name="Close" group="gripper">
         <joint name="m1n6s300_joint_finger_1" value="1.2" />
         <joint name="m1n6s300_joint_finger_2" value="1.2" />
-        <joint name="m1n6s300_joint_finger_3" value="1.2" />       
+        <joint name="m1n6s300_joint_finger_3" value="1.2" />
     </group_state>
     <group_state name="Vertical" group="arm">
         <joint name="m1n6s300_joint_1" value="3.1415" />

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group.launch
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group.launch
@@ -48,7 +48,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group_m1n6s300.launch
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group_m1n6s300.launch
@@ -49,7 +49,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
This PR contains changes to support ROS melodic. It is based on https://github.com/Kinovarobotics/kinova-ros/pull/150.

Changes:
- use types `urdf::LinkConstSharedPtr` and `urdf::JointSharedPtr` as replacement fopr boost pointers
- replace `move_group` by `move_group_interface`