### PR TITLE
remove world frame and visual from root frame

### DIFF
--- a/kinova_description/urdf/j2n4s300_standalone.xacro
+++ b/kinova_description/urdf/j2n4s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n4s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root" />
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/j2n4s300_standalone.xacro
+++ b/kinova_description/urdf/j2n4s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root" />
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n4s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n6s200_standalone.xacro
+++ b/kinova_description/urdf/j2n6s200_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n6s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n6s200_standalone.xacro
+++ b/kinova_description/urdf/j2n6s200_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s200.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/j2n7s300_standalone.xacro
+++ b/kinova_description/urdf/j2n7s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n7s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n7s300_standalone.xacro
+++ b/kinova_description/urdf/j2n7s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n7s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/j2s6s300_standalone.xacro
+++ b/kinova_description/urdf/j2s6s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2s6s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/j2s6s300_standalone.xacro
+++ b/kinova_description/urdf/j2s6s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2s6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2s7s300_standalone.xacro
+++ b/kinova_description/urdf/j2s7s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2s7s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2s7s300_standalone.xacro
+++ b/kinova_description/urdf/j2s7s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/j2s7s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -78,18 +78,7 @@
 
 
     <xacro:macro name="kinova_virtual_link" params="link_name">
-        <link name="${link_name}">
-            <visual>
-                <geometry>
-                    <box size = "0 0 0"/>
-                </geometry>
-            </visual>
-            <collision>
-                <geometry>
-                    <box size = "0 0 0"/>
-                </geometry>
-            </collision>
-        </link>
+        <link name="${link_name}"/>
     </xacro:macro>
 
     <xacro:macro name="kinova_virtual_joint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit">

--- a/kinova_description/urdf/m1n4s200_standalone.xacro
+++ b/kinova_description/urdf/m1n4s200_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n4s200.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/m1n4s200_standalone.xacro
+++ b/kinova_description/urdf/m1n4s200_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n4s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s200_standalone.xacro
+++ b/kinova_description/urdf/m1n6s200_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n6s200.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>

--- a/kinova_description/urdf/m1n6s200_standalone.xacro
+++ b/kinova_description/urdf/m1n6s200_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n6s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s300_standalone.xacro
+++ b/kinova_description/urdf/m1n6s300_standalone.xacro
@@ -21,15 +21,6 @@
 
   <link name="root"/>
 
-  <!-- for gazebo -->
-  <link name="world"/>
-  
-  <joint name="connect_root_and_world" type="fixed">
-    <child link="root" />
-    <parent link="world" />
-    <origin xyz="0 0 0" rpy="0 0 0" />    
-  </joint> 
-
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s300_standalone.xacro
+++ b/kinova_description/urdf/m1n6s300_standalone.xacro
@@ -19,22 +19,7 @@
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n6s300.xacro"/>
 
-  <link name="root">
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/>
-      </geometry>
-    <!--<material name="Black" /> -->
-    </visual>
-
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <box size = "0 0 0"/> 
-      </geometry>
-    </collision>     
-  </link>
+  <link name="root"/>
 
   <!-- for gazebo -->
   <link name="world"/>


### PR DESCRIPTION
This PR removes the visual from the root frame, which does not correspond to any real link of the robot, and it also removes the `world` frame since URDFs shall only contain the robot kinematic chain and connections to the world shall be provided by virtual joints in the SRDF (`virtual_joint`).
See also https://github.com/ros-industrial/universal_robot/issues/347 and https://github.com/ros-industrial/universal_robot/pull/284 for example issues caused by using the same joint connection in the URDF and SRDF.

Fixes #220 .