### PR TITLE
Define finger tips as revolute joints

### DIFF
--- a/kinova_description/urdf/j2n4s300.xacro
+++ b/kinova_description/urdf/j2n4s300.xacro
@@ -26,7 +26,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh" value="base" />
     <xacro:property name="link_1_mesh" value="shoulder" />
@@ -89,7 +89,7 @@
     <xacro:macro name="j2n4s300" params="base_parent prefix:=j2n4s300">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -104,9 +104,9 @@
 
         <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}"/>
-      
+
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_4" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_4" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
     <xacro:kinova_3fingers link_hand="${prefix}_link_4" prefix="${prefix}_"/>
     </xacro:macro>

--- a/kinova_description/urdf/j2n6s200.xacro
+++ b/kinova_description/urdf/j2n6s200.xacro
@@ -34,7 +34,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -107,9 +107,9 @@
 
 
     <xacro:macro name="j2n6s200" params="base_parent prefix:=j2n6s200">
-        
+
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -133,10 +133,10 @@
 
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
-    <xacro:kinova_2fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>		
+    <xacro:kinova_2fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
     </xacro:macro>
- 
+
 
 </root>

--- a/kinova_description/urdf/j2n6s300.xacro
+++ b/kinova_description/urdf/j2n6s300.xacro
@@ -34,7 +34,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -107,9 +107,9 @@
 
 
     <xacro:macro name="j2n6s300" params="base_parent prefix:=j2n6s300">
-        
+
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -133,10 +133,10 @@
 
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
-    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>		
+    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
     </xacro:macro>
- 
+
 
 </root>

--- a/kinova_description/urdf/j2n7s300.xacro
+++ b/kinova_description/urdf/j2n7s300.xacro
@@ -21,7 +21,7 @@
 
     <!-- Import all Gazebo-customization elements -->
     <xacro:include filename="$(find kinova_description)/urdf/kinova.gazebo" />
-  
+
     <xacro:property name="link_base_mesh" value="base" />
     <xacro:property name="link_1_mesh" value="shoulder" />
     <xacro:property name="link_2_mesh" value="arm_half_1" />
@@ -35,7 +35,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -119,7 +119,7 @@
     <xacro:macro name="j2n7s300" params="base_parent prefix:=j2n7s300">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -142,14 +142,14 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_7" link_mesh="${link_7_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_7_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}"/>    
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}"/>
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
         <xacro:kinova_3fingers link_hand="${prefix}_link_7" prefix="${prefix}_"/>
     </xacro:macro>
 
-    
-    
+
+
 </root>

--- a/kinova_description/urdf/j2s6s300.xacro
+++ b/kinova_description/urdf/j2s6s300.xacro
@@ -34,7 +34,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -109,7 +109,7 @@
     <xacro:macro name="j2s6s300" params="base_parent prefix:=j2s6s300">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -133,11 +133,11 @@
 
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
-    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>   
+    <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
 
     </xacro:macro>
-    
+
 
 </robot>

--- a/kinova_description/urdf/j2s7s300.xacro
+++ b/kinova_description/urdf/j2s7s300.xacro
@@ -35,7 +35,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -45,7 +45,7 @@
     <xacro:property name="link_5_mesh_no" value="8" />
     <xacro:property name="link_6_mesh_no" value="9" />
     <xacro:property name="link_7_mesh_no" value="55" />
-    
+
     <xacro:property name="joint_base" value="joint_base" />
     <xacro:property name="joint_base_type" value="fixed" />
     <xacro:property name="joint_base_axis_xyz" value="0 0 0" />
@@ -118,7 +118,7 @@
     <xacro:macro name="j2s7s300" params="base_parent prefix:=j2s7s300">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -141,15 +141,15 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_7" link_mesh="${link_7_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_7_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}"/>    
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_7" type="${joint_7_type}" parent="${prefix}_link_6" child="${prefix}_link_7" joint_axis_xyz="${joint_7_axis_xyz}" joint_origin_xyz="${joint_7_origin_xyz}" joint_origin_rpy="${joint_7_origin_rpy}" joint_lower_limit="${joint_7_lower_limit}" joint_upper_limit="${joint_7_upper_limit}"/>
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_7" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
         <xacro:kinova_3fingers link_hand="${prefix}_link_7" prefix="${prefix}_"/>
     </xacro:macro>
 
-    
+
 
 
 </root>

--- a/kinova_description/urdf/kinova.gazebo
+++ b/kinova_description/urdf/kinova.gazebo
@@ -4,7 +4,7 @@
 
 <xacro:macro name="gazebo_config" params="robot_namespace">
 
-    <!-- ros_control plugin -->  
+    <!-- ros_control plugin -->
     <gazebo>
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
         <robotNamespace>${robot_namespace}</robotNamespace>

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -32,13 +32,13 @@
                 </material>
             </visual>
 
-	    <!-- Adding ring to the model -->	
+	    <!-- Adding ring to the model -->
 	         <xacro:if value="${use_ring_mesh}">
 	           <visual>
                 <geometry>
                     <mesh
                         filename="package://kinova_description/meshes/${ring_mesh}.dae"/>
-                </geometry>              
+                </geometry>
              </visual>
 	    </xacro:if>
 
@@ -48,9 +48,9 @@
                         filename="package://kinova_description/meshes/${link_mesh}.dae"/>
                 </geometry>
             </collision>
-						<xacro:kinova_inertial mesh_no="${mesh_no}"/>	
-      </link>			
-		  	
+						<xacro:kinova_inertial mesh_no="${mesh_no}"/>
+      </link>
+
     </xacro:macro>
 
   <xacro:macro name="kinova_armjoint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit fixed:=false">
@@ -101,7 +101,7 @@
             <child link="${prefix}link_finger_${finger_number}"/>
             <axis xyz="0 0 1"/>
             <origin xyz="${finger_origin_xyz}" rpy="${finger_origin_rpy}"/>
-            <limit lower="0" upper="2" effort="2000" velocity="1"/>						
+            <limit lower="0" upper="2" effort="2000" velocity="1"/>
         </joint>
 		    <transmission name="${prefix}joint_finger_${finger_number}_trans">
 					<type>transmission_interface/SimpleTransmission</type>
@@ -113,20 +113,20 @@
 					<mechanicalReduction>1</mechanicalReduction>
 					</actuator>
 		    </transmission>
-				
-        
+
+
 
         <xacro:kinova_armlink link_name="${prefix}link_finger_tip_${finger_number}" link_mesh="finger_distal" mesh_no="58"/>
-        
+
         <joint name="${prefix}joint_finger_tip_${finger_number}" type="fixed">
             <parent link="${prefix}link_finger_${finger_number}"/>
             <child link="${prefix}link_finger_tip_${finger_number}"/>
             <axis xyz="0 0 1"/>
             <origin xyz="0.044 -0.003 0" rpy="0 0 0"/>
-            <limit lower="0" upper="2" effort="2000" velocity="1"/>        
+            <limit lower="0" upper="2" effort="2000" velocity="1"/>
         </joint>
 
     </xacro:macro>
 
-   
+
 </root>

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -118,7 +118,7 @@
 
         <xacro:kinova_armlink link_name="${prefix}link_finger_tip_${finger_number}" link_mesh="finger_distal" mesh_no="58"/>
 
-        <joint name="${prefix}joint_finger_tip_${finger_number}" type="fixed">
+        <joint name="${prefix}joint_finger_tip_${finger_number}" type="revolute">
             <parent link="${prefix}link_finger_${finger_number}"/>
             <child link="${prefix}link_finger_tip_${finger_number}"/>
             <axis xyz="0 0 1"/>

--- a/kinova_description/urdf/kinova_finger_set.xacro
+++ b/kinova_description/urdf/kinova_finger_set.xacro
@@ -18,7 +18,7 @@
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
 
-   
+
     <xacro:macro name="kinova_3fingers" params="link_hand prefix">
 
         <!-- finger1 Rot := Ry((1/2)*Pi) . Rx(12.1*((1/180)*Pi)+Pi) . Rz(-52.8*((1/180)*Pi)) -->
@@ -27,7 +27,7 @@
         <xacro:kinova_finger prefix="${prefix}" finger_number="2" hand="${link_hand}" finger_origin_xyz="0.02226 -0.02707 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.38614049188413"/>
         <!-- finger3 Rot := Ry((1/2)*Pi) . Rx(-10.58*((1/180)*Pi)) . Rz(-52.8*((1/180)*Pi)) -->
         <xacro:kinova_finger prefix="${prefix}" finger_number="3" hand="${link_hand}" finger_origin_xyz="-0.02226 -0.02707 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.75545216211587"/>
-        
+
     </xacro:macro>
 
 
@@ -37,7 +37,7 @@
         <xacro:kinova_finger prefix="${prefix}" finger_number="1" hand="${link_hand}" finger_origin_xyz="-0.0025 0.03095 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 1.57079632679490"/>
         <!-- finger2 Rot := Ry((1/2)*Pi) . Rz(-52.8*((1/180)*Pi))  -->
         <xacro:kinova_finger prefix="${prefix}" finger_number="2" hand="${link_hand}" finger_origin_xyz="-0.0025 -0.03095 -0.11482" finger_origin_rpy="-1.570796327 .649262481663582 -1.57079632679490"/>
-        
+
     </xacro:macro>
 
 

--- a/kinova_description/urdf/kinova_inertial.xacro
+++ b/kinova_description/urdf/kinova_inertial.xacro
@@ -30,31 +30,31 @@
    hand 3 finger  		55
    hand_2finger   		56
    finger_proximal		57
-   finger_distal      58 
+   finger_distal      58
 -->
 
-<xacro:macro name="inertia_cylinder" params="mass height radius axis:=0">  
+<xacro:macro name="inertia_cylinder" params="mass height radius axis:=0">
 
   <!-- z Axis -->
   <xacro:unless value="${axis}">
-    <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0" 
-              iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0" 
+    <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0"
+              iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0"
               izz="${0.5*mass*radius*radius}" />
-  </xacro:unless>   
+  </xacro:unless>
 
   <!-- y Axis -->
   <xacro:unless value="${axis-1}">
-   <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0" 
+   <inertia  ixx="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0"
              iyy="${0.5*mass*radius*radius}"
-             izz="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0" />             
-  </xacro:unless> 
+             izz="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0" />
+  </xacro:unless>
 
   <!-- x Axis -->
   <xacro:unless value="${axis-2}">
-   <inertia  ixx="${0.5*mass*radius*radius}" 
-             iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0" 
+   <inertia  ixx="${0.5*mass*radius*radius}"
+             iyy="${0.083333 * mass * (3*radius*radius + height*height)}" iyz="0"
              izz="${0.083333 * mass * (3*radius*radius + height*height)}" ixy="0" ixz="0" />
-  </xacro:unless> 
+  </xacro:unless>
 </xacro:macro>
 
 
@@ -64,116 +64,116 @@
     <inertial>
         <mass value="0.46784" />
         <origin xyz="0 0 0.1255" rpy="0 0 0"/>
-        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.46784"/>  
-    </inertial> 
-  </xacro:unless>      
+        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.46784"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- shoulder = 1 -->
   <xacro:unless value="${mesh_no-1}">
     <inertial>
         <mass value="0.7477" />
         <origin xyz="0 -0.002 -0.0605" />
-        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.7477"/>  
-    </inertial>   
-  </xacro:unless>      
+        <xacro:inertia_cylinder height="0.14"  radius = "0.04" mass="0.7477"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- arm = 2-->
   <xacro:unless value="${mesh_no-2}">
     <inertial>
         <mass value="0.99" />
         <origin xyz="0 -0.2065 -0.01" />
-        <xacro:inertia_cylinder height="0.35"  radius = "0.04" mass="0.99" axis="1"/>  
-    </inertial>  
-  </xacro:unless>   
+        <xacro:inertia_cylinder height="0.35"  radius = "0.04" mass="0.99" axis="1"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- forearm = 3 -->
   <xacro:unless value="${mesh_no-3}">
     <inertial>
         <mass value="0.6763" />
         <origin xyz="0 0.081 -0.0086" />
-        <xacro:inertia_cylinder height="0.15"  radius = "0.03" mass="0.6763" axis="1"/>  
-    </inertial>  
-  </xacro:unless>       
+        <xacro:inertia_cylinder height="0.15"  radius = "0.03" mass="0.6763" axis="1"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- wrist = 4 -->
   <xacro:unless value="${mesh_no-4}">
     <inertial>
         <mass value="0.426367" />
         <origin xyz="0 -0.037 -0.0642" />
-        <xacro:inertia_cylinder height="0.02"  radius = "0.04" mass="0.1785"/>  
-    </inertial>  
-  </xacro:unless>  
+        <xacro:inertia_cylinder height="0.02"  radius = "0.04" mass="0.1785"/>
+    </inertial>
+  </xacro:unless>
 
 <!--arm_mico       		5 -->
   <xacro:unless value="${mesh_no-5}">
     <inertial>
         <mass value="0.85968" />
         <origin xyz="0 -0.145  -0.0076"/>
-        <xacro:inertia_cylinder height="0.25"  radius = "0.03" mass="0.85968" axis="1"/>  
-    </inertial>  
+        <xacro:inertia_cylinder height="0.25"  radius = "0.03" mass="0.85968" axis="1"/>
+    </inertial>
   </xacro:unless>
- 
+
 <!--   arm_half1 (7dof)		6 -->
   <xacro:unless value="${mesh_no-6}">
     <inertial>
         <mass value="0.8447" />
         <origin xyz="0 -0.103563213 0" />
-        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447" axis="1"/>  
-    </inertial>  
-  </xacro:unless> 
+        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447" axis="1"/>
+    </inertial>
+  </xacro:unless>
 
 <!--   arm_half2 (7dof)		7 -->
   <xacro:unless value="${mesh_no-7}">
     <inertial>
         <mass value="0.8447" />
         <origin xyz="0 0 -0.1022447445" />
-        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447"/>  
-    </inertial>  
-  </xacro:unless> 
+        <xacro:inertia_cylinder height="0.18"  radius = "0.03" mass="0.8447"/>
+    </inertial>
+  </xacro:unless>
 
 <!--   wrist_spherical_1  8 -->
   <xacro:unless value="${mesh_no-8}">
     <inertial>
         <mass value="0.463" />
         <origin xyz="0 0.0028848942 -0.0541932613" />
-        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463"/>  
-    </inertial>  
-  </xacro:unless> 
-<!--   wrist_spherical_2  9 -->   
+        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463"/>
+    </inertial>
+  </xacro:unless>
+<!--   wrist_spherical_2  9 -->
   <xacro:unless value="${mesh_no-9}">
     <inertial>
         <mass value="0.463" />
         <origin xyz="0 0.0497208855 -0.0028562765" />
-        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463" axis="1"/>  
-    </inertial>  
-  </xacro:unless>  
+        <xacro:inertia_cylinder height="0.1"  radius = "0.02" mass="0.463" axis="1"/>
+    </inertial>
+  </xacro:unless>
 
-<!--   forearm_mico  10 -->   
+<!--   forearm_mico  10 -->
   <xacro:unless value="${mesh_no-10}">
     <inertial>
         <mass value="0.606" />
         <origin xyz="0 0.0463 -0.0065" />
-        <xacro:inertia_cylinder height="0.08"  radius = "0.02" mass="0.606" axis="1"/>  
-    </inertial>  
-  </xacro:unless>  
+        <xacro:inertia_cylinder height="0.08"  radius = "0.02" mass="0.606" axis="1"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- hand 3 finger = 55 -->
   <xacro:unless value="${mesh_no - 55}">
     <inertial>
         <mass value="0.99" />
         <origin xyz="0 0 -0.06" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.727"/>  
-    </inertial> 
-  </xacro:unless> 
+        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.727"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- hand 2 finger = 56 -->
   <xacro:unless value="${mesh_no - 56}">
    <inertial>
         <mass value="0.78" />
         <origin xyz="0 0 -0.06" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.78"/>  
-    </inertial> 
-  </xacro:unless> 
+        <xacro:inertia_cylinder height="0.03"  radius = "0.04" mass="0.78"/>
+    </inertial>
+  </xacro:unless>
 
   <!-- finger_proximal = 57 -->
   <xacro:unless value="${mesh_no - 57}">
@@ -181,19 +181,19 @@
         <mass value="0.01" />
         <origin xyz="0.022 0 0" />
         <xacro:inertia_cylinder height="0.03"  radius = "0.004" mass="0.01"/>
-    </inertial>       
+    </inertial>
 
-  </xacro:unless> 
+  </xacro:unless>
 
   <!-- finger_distal = 58 -->
   <xacro:unless value="${mesh_no - 58}">
     <inertial>
         <mass value="0.01" />
         <origin xyz="0.022 0 0" />
-        <xacro:inertia_cylinder height="0.03"  radius = "0.004" mass="0.01"/>  
-    </inertial> 
-  </xacro:unless> 
-      
+        <xacro:inertia_cylinder height="0.03"  radius = "0.004" mass="0.01"/>
+    </inertial>
+  </xacro:unless>
+
 </xacro:macro>
 </root>
 

--- a/kinova_description/urdf/m1n4s200.xacro
+++ b/kinova_description/urdf/m1n4s200.xacro
@@ -32,7 +32,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -89,7 +89,7 @@
     <xacro:macro name="m1n4s200" params="base_parent prefix:=m1n4s200">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -106,11 +106,11 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}"/>
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_4" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_4" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
         <xacro:kinova_2fingers link_hand="${prefix}_link_4" prefix="${prefix}_"/>
     </xacro:macro>
 
-    
+
 
 </root>

--- a/kinova_description/urdf/m1n6s200.xacro
+++ b/kinova_description/urdf/m1n6s200.xacro
@@ -34,7 +34,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -109,7 +109,7 @@
     <xacro:macro name="m1n6s200" params="base_parent prefix:=m1n6s200">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -133,11 +133,11 @@
 
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
     <xacro:kinova_2fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
     </xacro:macro>
 
-    
+
 
 </root>

--- a/kinova_description/urdf/m1n6s300.xacro
+++ b/kinova_description/urdf/m1n6s300.xacro
@@ -34,7 +34,7 @@
         base 0, shoulder 1, arm 2, forearm 3, wrist 4, arm_mico 5,
         arm_half1 (7dof)	6, arm_half2 (7dof) 7, wrist_spherical_1  8, wrist_spherical_2  9
         fore_arm_mico 10,
-        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58 
+        hand 3 finger 55, hand_2finger 56, finger_proximal 57, finger_distal 58
     -->
     <xacro:property name="link_base_mesh_no" value="0" />
     <xacro:property name="link_1_mesh_no" value="1" />
@@ -109,7 +109,7 @@
     <xacro:macro name="m1n6s300" params="base_parent prefix:=m1n6s300">
 
         <xacro:gazebo_config robot_namespace="${prefix}"/>
-    
+
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" fixed="true"/>
 
@@ -132,11 +132,11 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}"/>
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>
-        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>    
+        <xacro:kinova_virtual_joint joint_name="${prefix}_joint_end_effector" type="${joint_end_effector_type}" parent="${prefix}_link_6" child="${prefix}_end_effector" joint_axis_xyz="${joint_end_effector_axis_xyz}" joint_origin_xyz="${joint_end_effector_origin_xyz}" joint_origin_rpy="${joint_end_effector_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
     <xacro:kinova_3fingers link_hand="${prefix}_link_6" prefix="${prefix}_"/>
     </xacro:macro>
 
-    
+
 
 </root>

--- a/kinova_description/urdf/two_arm_robot_example_standalone.xacro
+++ b/kinova_description/urdf/two_arm_robot_example_standalone.xacro
@@ -25,15 +25,15 @@
       <geometry>
         <box size = "0 0 0"/>
       </geometry>
-    
+
     </visual>
 
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
-        <box size = "0 0 0"/> 
+        <box size = "0 0 0"/>
       </geometry>
-    </collision>     
+    </collision>
   </link>
 
 	<link name="left_arm_mount">
@@ -45,14 +45,14 @@
 	 <joint name="left_arm_attach" type="fixed">
     <child link="left_arm_mount" />
     <parent link="root" />
-    <origin xyz="-0.2 0 0" rpy="0 0 1.5707" />   
+    <origin xyz="-0.2 0 0" rpy="0 0 1.5707" />
   </joint>
 
   <joint name="right_arm_attach" type="fixed">
     <child link="right_arm_mount" />
     <parent link="root" />
-    <origin xyz="0.2 0 0" rpy="0 0 1.5707" />    
-  </joint> 
+    <origin xyz="0.2 0 0" rpy="0 0 1.5707" />
+  </joint>
 
   <xacro:j2n6s300  base_parent="left_arm_mount" prefix="left"/>
 

--- a/kinova_driver/src/kinova_arm.cpp
+++ b/kinova_driver/src/kinova_arm.cpp
@@ -99,7 +99,7 @@ KinovaArm::KinovaArm(KinovaComm &arm, const ros::NodeHandle &nodeHandle, const s
     arm_joint_number_ = kinova_robotType_[3]-'0';
     robot_mode_ = kinova_robotType_[4];
     finger_number_ = kinova_robotType_[5]-'0';
-    joint_total_number_ = arm_joint_number_ + finger_number_;
+    joint_total_number_ = arm_joint_number_ + 2*finger_number_;
 
     if (robot_category_=='j') // jaco robot
     {
@@ -163,6 +163,10 @@ KinovaArm::KinovaArm(KinovaComm &arm, const ros::NodeHandle &nodeHandle, const s
     for (int i = 0; i<finger_number_; i++)
     {
         joint_names_[arm_joint_number_+i] = tf_prefix_ + "joint_finger_" + boost::lexical_cast<std::string>(i+1);
+    }
+    for (int i = 0; i<finger_number_; i++)
+    {
+        joint_names_[arm_joint_number_+finger_number_+i] = tf_prefix_ + "joint_finger_tip_" + boost::lexical_cast<std::string>(i+1);
     }
 
     /* Set up Services */
@@ -541,14 +545,23 @@ void KinovaArm::publishJointAngles(void)
 
     if(finger_number_==2)
     {
-        joint_state.position[joint_total_number_-2] = fingers.Finger1/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-1] = fingers.Finger2/6800*80*M_PI/180;
+        // proximal phalanges
+        joint_state.position[joint_total_number_-4] = fingers.Finger1/6800*80*M_PI/180;
+        joint_state.position[joint_total_number_-3] = fingers.Finger2/6800*80*M_PI/180;
+        // distal phalanges
+        joint_state.position[joint_total_number_-2] = 0;
+        joint_state.position[joint_total_number_-1] = 0;
     }
     else if(finger_number_==3)
     {
-        joint_state.position[joint_total_number_-3] = fingers.Finger1/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-2] = fingers.Finger2/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-1] = fingers.Finger3/6800*80*M_PI/180;
+        // proximal phalanges
+        joint_state.position[joint_total_number_-6] = fingers.Finger1/6800*80*M_PI/180;
+        joint_state.position[joint_total_number_-5] = fingers.Finger2/6800*80*M_PI/180;
+        joint_state.position[joint_total_number_-4] = fingers.Finger3/6800*80*M_PI/180;
+        // distal phalanges
+        joint_state.position[joint_total_number_-3] = 0;
+        joint_state.position[joint_total_number_-2] = 0;
+        joint_state.position[joint_total_number_-1] = 0;
     }
 
 
@@ -561,16 +574,8 @@ void KinovaArm::publishJointAngles(void)
     joint_state.velocity[2] = current_vels.Actuator3;
     joint_state.velocity[3] = current_vels.Actuator4;
     // no velocity info for fingers
-    if(finger_number_==2)
-    {
-        joint_state.velocity[joint_total_number_-2] = 0;
-        joint_state.velocity[joint_total_number_-1] = 0;
-    }
-    else if(finger_number_==3)
-    {
-        joint_state.velocity[joint_total_number_-3] = 0;
-        joint_state.velocity[joint_total_number_-2] = 0;
-        joint_state.velocity[joint_total_number_-1] = 0;
+    for(int fi=arm_joint_number_; fi<joint_total_number_; fi++) {
+        joint_state.velocity[fi] = 0;
     }
 
     if (arm_joint_number_ >= 6)
@@ -613,16 +618,8 @@ void KinovaArm::publishJointAngles(void)
     joint_state.effort[2] = joint_tqs.Actuator3;
     joint_state.effort[3] = joint_tqs.Actuator4;
     // no effort info for fingers
-    if(finger_number_==2)
-    {
-        joint_state.effort[joint_total_number_-2] = 0;
-        joint_state.effort[joint_total_number_-1] = 0;
-    }
-    else if(finger_number_==3)
-    {
-        joint_state.effort[joint_total_number_-3] = 0;
-        joint_state.effort[joint_total_number_-2] = 0;
-        joint_state.effort[joint_total_number_-1] = 0;
+    for(int fi=arm_joint_number_; fi<joint_total_number_; fi++) {
+        joint_state.effort[fi] = 0;
     }
     if (arm_joint_number_ >= 6)
     {


### PR DESCRIPTION
The joints for fingertips of the Jaco are set to `fixed`. This is wrong. There is no static transform between the proximal and distal finger. They are not actuated but still can have a non-static transform.

I assume that this is also the cause for the missing finger transforms that are published by the `robot_state_publisher` (https://github.com/Kinovarobotics/kinova-ros/issues/228).

This PR sets `joint_finger_tip_` to type `revolute`. It also cleans up trailing whitespace characters.