### PR TITLE
Fix the robot bouncing issue in Gazebo 7

### DIFF
--- a/kinova_control/src/move_robot.py
+++ b/kinova_control/src/move_robot.py
@@ -4,7 +4,9 @@
 import rospy
 from trajectory_msgs.msg import JointTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
+from std_srvs.srv import Empty
 import argparse
+import time
 
 def argumentParser(argument):
   """ Argument parser """
@@ -66,7 +68,12 @@ if __name__ == '__main__':
     rospy.init_node('move_robot_using_trajectory_msg')		
     prefix, nbJoints, nbfingers = argumentParser(None)    
     #allow gazebo to launch
-    rospy.sleep(1)
+    time.sleep(5)
+
+    # Unpause the physics
+    rospy.wait_for_service('/gazebo/unpause_physics')
+    unpause_gazebo = rospy.ServiceProxy('/gazebo/unpause_physics', Empty)
+    resp = unpause_gazebo()
 
     if (nbJoints==6):
       #home robots

--- a/kinova_description/urdf/j2n4s300.xacro
+++ b/kinova_description/urdf/j2n4s300.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/j2n4s300_standalone.xacro
+++ b/kinova_description/urdf/j2n4s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root" />
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n4s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n4s300_standalone.xacro
+++ b/kinova_description/urdf/j2n4s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2n4s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n4s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n4s300.xacro"/>

--- a/kinova_description/urdf/j2n6s200.xacro
+++ b/kinova_description/urdf/j2n6s200.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/j2n6s200_standalone.xacro
+++ b/kinova_description/urdf/j2n6s200_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n6s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n6s200_standalone.xacro
+++ b/kinova_description/urdf/j2n6s200_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2n6s200">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n6s200">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s200.xacro"/>

--- a/kinova_description/urdf/j2n6s300.xacro
+++ b/kinova_description/urdf/j2n6s300.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n6s300_standalone.xacro
+++ b/kinova_description/urdf/j2n6s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2n6s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n6s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s300.xacro"/>

--- a/kinova_description/urdf/j2n7s300.xacro
+++ b/kinova_description/urdf/j2n7s300.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/j2n7s300_standalone.xacro
+++ b/kinova_description/urdf/j2n7s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2n7s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2n7s300_standalone.xacro
+++ b/kinova_description/urdf/j2n7s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2n7s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2n7s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n7s300.xacro"/>

--- a/kinova_description/urdf/j2s6s300_standalone.xacro
+++ b/kinova_description/urdf/j2s6s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2s6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2s6s300_standalone.xacro
+++ b/kinova_description/urdf/j2s6s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2s6s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2s6s300.xacro"/>

--- a/kinova_description/urdf/j2s7s300.xacro
+++ b/kinova_description/urdf/j2s7s300.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/j2s7s300_standalone.xacro
+++ b/kinova_description/urdf/j2s7s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:j2s7s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/j2s7s300_standalone.xacro
+++ b/kinova_description/urdf/j2s7s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2s7s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s7s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2s7s300.xacro"/>

--- a/kinova_description/urdf/kinova.gazebo
+++ b/kinova_description/urdf/kinova.gazebo
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<root xmlns:xacro="http://ros.org/wiki/xacro">
+<root xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <xacro:macro name="gazebo_config" params="robot_namespace">
 

--- a/kinova_description/urdf/kinova.gazebo
+++ b/kinova_description/urdf/kinova.gazebo
@@ -9,6 +9,7 @@
       <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
         <robotNamespace>${robot_namespace}</robotNamespace>
         <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+        <legacyModeNS>true</legacyModeNS>
       </plugin>
     </gazebo>
 

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -13,7 +13,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro">
+	xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <xacro:include filename="$(find kinova_description)/urdf/kinova_inertial.xacro" />
 

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -66,10 +66,10 @@
      <transmission name="${joint_name}_trans">
         <type>transmission_interface/SimpleTransmission</type>
         <joint name="${joint_name}">
-          <hardwareInterface>EffortJointInterface</hardwareInterface>
+          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
         <actuator name="${joint_name}_actuator">
-          <hardwareInterface>EffortJointInterface</hardwareInterface>
+          <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         <mechanicalReduction>160</mechanicalReduction>
         </actuator>
      </transmission>
@@ -106,10 +106,10 @@
 		    <transmission name="${prefix}joint_finger_${finger_number}_trans">
 					<type>transmission_interface/SimpleTransmission</type>
 					<joint name="${prefix}joint_finger_${finger_number}">
-					  <hardwareInterface>EffortJointInterface</hardwareInterface>
+					  <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
 					</joint>
 					<actuator name="${prefix}joint_finger_${finger_number}_actuator">
-					<hardwareInterface>EffortJointInterface</hardwareInterface>
+					<hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
 					<mechanicalReduction>1</mechanicalReduction>
 					</actuator>
 		    </transmission>

--- a/kinova_description/urdf/kinova_finger_set.xacro
+++ b/kinova_description/urdf/kinova_finger_set.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
 

--- a/kinova_description/urdf/kinova_inertial.xacro
+++ b/kinova_description/urdf/kinova_inertial.xacro
@@ -13,7 +13,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro">
+	xmlns:xacro="http://www.ros.org/wiki/xacro">
 
 <!-- links      		mesh_no
    base           		0

--- a/kinova_description/urdf/m1n4s200.xacro
+++ b/kinova_description/urdf/m1n4s200.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/m1n4s200_standalone.xacro
+++ b/kinova_description/urdf/m1n4s200_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="m1n4s200">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="m1n4s200">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n4s200.xacro"/>

--- a/kinova_description/urdf/m1n4s200_standalone.xacro
+++ b/kinova_description/urdf/m1n4s200_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n4s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s200.xacro
+++ b/kinova_description/urdf/m1n6s200.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/m1n6s200_standalone.xacro
+++ b/kinova_description/urdf/m1n6s200_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n6s200  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s200_standalone.xacro
+++ b/kinova_description/urdf/m1n6s200_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="m1n6s200">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="m1n6s200">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n6s200.xacro"/>

--- a/kinova_description/urdf/m1n6s300.xacro
+++ b/kinova_description/urdf/m1n6s300.xacro
@@ -14,7 +14,7 @@
     xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-    xmlns:xacro="http://ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:include filename="$(find kinova_description)/urdf/kinova_common.xacro" />
     <xacro:include filename="$(find kinova_description)/urdf/kinova_finger_set.xacro" />

--- a/kinova_description/urdf/m1n6s300_standalone.xacro
+++ b/kinova_description/urdf/m1n6s300_standalone.xacro
@@ -21,6 +21,15 @@
 
   <link name="root"/>
 
+  <!-- for gazebo -->
+  <link name="world"/>
+  
+  <joint name="connect_root_and_world" type="fixed">
+    <child link="root" />
+    <parent link="world" />
+    <origin xyz="0 0 0" rpy="0 0 0" />    
+  </joint> 
+
   <xacro:property name="robot_root" value="root" />
 
   <xacro:m1n6s300  base_parent="${robot_root}"/>

--- a/kinova_description/urdf/m1n6s300_standalone.xacro
+++ b/kinova_description/urdf/m1n6s300_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="m1n6s300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="m1n6s300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/m1n6s300.xacro"/>

--- a/kinova_description/urdf/two_arm_robot_example_standalone.xacro
+++ b/kinova_description/urdf/two_arm_robot_example_standalone.xacro
@@ -14,7 +14,7 @@
 	xmlns:rendering="http://playerstage.sourceforge.net/gazebo/xmlschema/#rendering"
     xmlns:renderable="http://playerstage.sourceforge.net/gazebo/xmlschema/#renderable"
     xmlns:physics="http://playerstage.sourceforge.net/gazebo/xmlschema/#physics"
-	xmlns:xacro="http://ros.org/wiki/xacro" name="j2s6a300">
+	xmlns:xacro="http://www.ros.org/wiki/xacro" name="j2s6a300">
 
 
   <xacro:include filename="$(find kinova_description)/urdf/j2n6s300.xacro"/>

--- a/kinova_gazebo/launch/robot_launch.launch
+++ b/kinova_gazebo/launch/robot_launch.launch
@@ -3,7 +3,7 @@
   <!-- these are the arguments you can pass this launch file, for example paused:=true -->  
   <arg name="kinova_robotType" default="j2n6s300"/>
   <arg name="kinova_robotName" default="$(arg kinova_robotType)"/>
-  <arg name="paused" default="false"/>
+  <arg name="paused" default="true"/>
   <arg name="use_sim_time" default="true"/>
   <arg name="gui" default="true"/>
   <arg name="headless" default="false"/>
@@ -26,8 +26,32 @@
     command="$(find xacro)/xacro --inorder '$(find kinova_description)/urdf/$(arg kinova_robotType)_standalone.xacro'" />
 
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
-  <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
-    args="-urdf -model $(arg kinova_robotName) -param robot_description"/>
+  <!-- For the 6DOF -->
+  <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" unless="$(arg is7dof)"
+    args="-urdf -model $(arg kinova_robotName) -param robot_description
+        -J $(arg kinova_robotType)_joint_1 0.0
+        -J $(arg kinova_robotType)_joint_2 2.9
+        -J $(arg kinova_robotType)_joint_3 1.3
+        -J $(arg kinova_robotType)_joint_4 -2.07
+        -J $(arg kinova_robotType)_joint_5 1.4
+        -J $(arg kinova_robotType)_joint_6 0.0
+        -J $(arg kinova_robotType)_joint_finger_1 1.0
+        -J $(arg kinova_robotType)_joint_finger_2 1.0
+        -J $(arg kinova_robotType)_joint_finger_3 1.0" />
+
+  <!-- For the 7DOF -->
+    <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen" if="$(arg is7dof)"
+    args="-urdf -model $(arg kinova_robotName) -param robot_description
+        -J $(arg kinova_robotType)_joint_1 0.0
+        -J $(arg kinova_robotType)_joint_2 2.9
+        -J $(arg kinova_robotType)_joint_3 0.0
+        -J $(arg kinova_robotType)_joint_4 1.3
+        -J $(arg kinova_robotType)_joint_5 -2.07
+        -J $(arg kinova_robotType)_joint_6 1.4
+        -J $(arg kinova_robotType)_joint_7 0.0
+        -J $(arg kinova_robotType)_joint_finger_1 1.0
+        -J $(arg kinova_robotType)_joint_finger_2 1.0
+        -J $(arg kinova_robotType)_joint_finger_3 1.0" />
 
   <!-- ros_control launch file -->
   <include file="$(find kinova_control)/launch/kinova_control.launch">


### PR DESCRIPTION
Changelog : 
- Put world frame back.
- Now the Gazebo launch pauses Gazebo by default and the move_home.py script unpauses it before moving the robot. This ensures the controllers are loaded properly and that the robot is loaded in its default position.
- Added the default position in the Gazebo launch file (not only in the script).
- Added the <legacyModeNS> tag in the gazebo_ros_control plugin definition.
- Updated the xmlns:xacro links in the XACRO files.

Addresses #249  and #247 