### PR TITLE
convert finger angles to radian

### DIFF
--- a/kinova_driver/src/kinova_arm.cpp
+++ b/kinova_driver/src/kinova_arm.cpp
@@ -546,8 +546,8 @@ void KinovaArm::publishJointAngles(void)
     if(finger_number_==2)
     {
         // proximal phalanges
-        joint_state.position[joint_total_number_-4] = fingers.Finger1/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-3] = fingers.Finger2/6800*80*M_PI/180;
+        joint_state.position[joint_total_number_-4] = fingers.Finger1 * M_PI/180;
+        joint_state.position[joint_total_number_-3] = fingers.Finger2 * M_PI/180;
         // distal phalanges
         joint_state.position[joint_total_number_-2] = 0;
         joint_state.position[joint_total_number_-1] = 0;
@@ -555,9 +555,9 @@ void KinovaArm::publishJointAngles(void)
     else if(finger_number_==3)
     {
         // proximal phalanges
-        joint_state.position[joint_total_number_-6] = fingers.Finger1/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-5] = fingers.Finger2/6800*80*M_PI/180;
-        joint_state.position[joint_total_number_-4] = fingers.Finger3/6800*80*M_PI/180;
+        joint_state.position[joint_total_number_-6] = fingers.Finger1 * M_PI/180;
+        joint_state.position[joint_total_number_-5] = fingers.Finger2 * M_PI/180;
+        joint_state.position[joint_total_number_-4] = fingers.Finger3 * M_PI/180;
         // distal phalanges
         joint_state.position[joint_total_number_-3] = 0;
         joint_state.position[joint_total_number_-2] = 0;


### PR DESCRIPTION
The `FingerAngles` that are published on topic `out/finger_position` (as `kinova_msgs/FingerPosition`) appears to be in degree. I couldn't find a comment in the code or the message definition to verify that.

As described in https://github.com/Kinovarobotics/kinova-ros/issues/253, these angles are converted to radians for the `sensor_msgs/JointState` by a very small factor (0.000205333).

This PR assumes that the finger angles are given in degree and correctly converts the degree to radian values for the `sensor_msgs/JointState` message in the same way as it is done for the arm joint angles (`kinova_msgs/JointAngles`). Fixes #253 .