### PR TITLE
Add distal fingers controllers for Gazebo simulation

### DIFF
--- a/kinova_control/config/j2n6s300_control.yaml
+++ b/kinova_control/config/j2n6s300_control.yaml
@@ -115,6 +115,27 @@ j2n6s300:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: j2n6s300_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: j2n6s300_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_3_position_controller:
+    joint: j2n6s300_joint_finger_tip_3
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: j2n6s300_joint_1
     pid:

--- a/kinova_control/config/j2n7s300_control.yaml
+++ b/kinova_control/config/j2n7s300_control.yaml
@@ -124,6 +124,27 @@ j2n7s300:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: j2n7s300_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: j2n7s300_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_3_position_controller:
+    joint: j2n7s300_joint_finger_tip_3
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: j2n7s300_joint_1
     pid:

--- a/kinova_control/config/j2s6s300_control.yaml
+++ b/kinova_control/config/j2s6s300_control.yaml
@@ -115,6 +115,27 @@ j2s6s300:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: j2s6s300_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: j2s6s300_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_3_position_controller:
+    joint: j2s6s300_joint_finger_tip_3
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: j2s6s300_joint_1
     pid:

--- a/kinova_control/config/j2s7s300_control.yaml
+++ b/kinova_control/config/j2s7s300_control.yaml
@@ -124,6 +124,27 @@ j2s7s300:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: j2s7s300_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: j2s7s300_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_3_position_controller:
+    joint: j2s7s300_joint_finger_tip_3
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: j2s7s300_joint_1
     pid:

--- a/kinova_control/config/m1n6s200_control.yaml
+++ b/kinova_control/config/m1n6s200_control.yaml
@@ -99,6 +99,20 @@ m1n6s200:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: m1n6s200_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: m1n6s200_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: m1n6s200_joint_1
     pid:

--- a/kinova_control/config/m1n6s300_control.yaml
+++ b/kinova_control/config/m1n6s300_control.yaml
@@ -115,6 +115,27 @@ m1n6s300:
       i: 0
       p: 10
     type: effort_controllers/JointPositionController
+  finger_tip_1_position_controller:
+    joint: m1n6s300_joint_finger_tip_1
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_2_position_controller:
+    joint: m1n6s300_joint_finger_tip_2
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
+  finger_tip_3_position_controller:
+    joint: m1n6s300_joint_finger_tip_3
+    pid:
+      d: 0
+      i: 0
+      p: 0.5
+    type: effort_controllers/JointPositionController
   joint_1_position_controller:
     joint: m1n6s300_joint_1
     pid:

--- a/kinova_control/launch/kinova_control.launch
+++ b/kinova_control/launch/kinova_control.launch
@@ -16,7 +16,8 @@
                joint_3_position_controller joint_4_position_controller
                joint_5_position_controller joint_6_position_controller 
                finger_2_position_controller finger_1_position_controller 
-               finger_3_position_controller
+               finger_3_position_controller finger_tip_1_position_controller
+               finger_tip_2_position_controller finger_tip_3_position_controller
                joint_state_controller"/> 
     </group>
     <group if="$(arg is7dof)">
@@ -27,7 +28,8 @@
                joint_3_position_controller joint_4_position_controller
                joint_5_position_controller joint_6_position_controller joint_7_position_controller
                finger_2_position_controller finger_1_position_controller 
-               finger_3_position_controller
+               finger_3_position_controller finger_tip_1_position_controller
+               finger_tip_2_position_controller finger_tip_3_position_controller
                joint_state_controller"/> 
     </group>
   </group>
@@ -38,6 +40,9 @@
       output="screen" ns="$(arg kinova_robotName)" 
       args="effort_joint_trajectory_controller
       effort_finger_trajectory_controller    
+      finger_tip_1_position_controller
+      finger_tip_2_position_controller 
+      finger_tip_3_position_controller
       joint_state_controller"/>    
   </group>
 

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -125,6 +125,16 @@
             <origin xyz="0.044 -0.003 0" rpy="0 0 0"/>
             <limit lower="0" upper="2" effort="2000" velocity="1"/>
         </joint>
+        <transmission name="${prefix}joint_finger_tip_${finger_number}_trans">
+					<type>transmission_interface/SimpleTransmission</type>
+					<joint name="${prefix}joint_finger_tip_${finger_number}">
+					  <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+					</joint>
+					<actuator name="${prefix}joint_finger_tip_${finger_number}_actuator">
+					<hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+					<mechanicalReduction>1</mechanicalReduction>
+					</actuator>
+        </transmission>
 
     </xacro:macro>
 

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/config/j2n6s300.srdf
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/config/j2n6s300.srdf
@@ -14,11 +14,8 @@
     </group>
     <group name="gripper">
         <link name="j2n6s300_link_finger_1" />
-        <link name="j2n6s300_link_finger_tip_1" />
         <link name="j2n6s300_link_finger_2" />
-        <link name="j2n6s300_link_finger_tip_2" />
         <link name="j2n6s300_link_finger_3" />
-        <link name="j2n6s300_link_finger_tip_3" />
         <link name="j2n6s300_end_effector" />
 				<joint name="j2n6s300_joint_finger_1" />
         <joint name="j2n6s300_joint_finger_2" />

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/config/j2s6s300.srdf
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/config/j2s6s300.srdf
@@ -14,11 +14,8 @@
     </group>
     <group name="gripper">
         <link name="j2s6s300_link_finger_1" />
-        <link name="j2s6s300_link_finger_tip_1" />
         <link name="j2s6s300_link_finger_2" />
-        <link name="j2s6s300_link_finger_tip_2" />
         <link name="j2s6s300_link_finger_3" />
-        <link name="j2s6s300_link_finger_tip_3" />
         <link name="j2s6s300_end_effector" />
         <joint name="j2s6s300_joint_finger_1" />
         <joint name="j2s6s300_joint_finger_2" />

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/config/j2s7s300.srdf
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/config/j2s7s300.srdf
@@ -15,11 +15,8 @@
     <group name="gripper">
         <link name="j2s7s300_end_effector" />
         <link name="j2s7s300_link_finger_1" />
-        <link name="j2s7s300_link_finger_tip_1" />
         <link name="j2s7s300_link_finger_2" />
-        <link name="j2s7s300_link_finger_tip_2" />
         <link name="j2s7s300_link_finger_3" />
-        <link name="j2s7s300_link_finger_tip_3" />
 				<joint name="j2s7s300_joint_finger_1" />
         <joint name="j2s7s300_joint_finger_2" />
         <joint name="j2s7s300_joint_finger_3" />

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/config/m1n6s300.srdf
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/config/m1n6s300.srdf
@@ -15,12 +15,9 @@
     <group name="gripper">
         <link name="m1n6s300_end_effector" />
         <link name="m1n6s300_link_finger_1" />
-        <link name="m1n6s300_link_finger_tip_1" />
         <link name="m1n6s300_link_finger_2" />
-        <link name="m1n6s300_link_finger_tip_2" />
         <link name="m1n6s300_link_finger_3" />
-        <link name="m1n6s300_link_finger_tip_3" />
-				<joint name="m1n6s300_joint_finger_1" />
+        <joint name="m1n6s300_joint_finger_1" />
         <joint name="m1n6s300_joint_finger_2" />
         <joint name="m1n6s300_joint_finger_3" />
     </group>


### PR DESCRIPTION
Changing the finger tips joints for revolute joints worked for the real robot in #242 , but the finger tips were left hanging in Gazebo.
This PR is adding the virtual controllers to control the finger tips so they don't just fall.
I did not add the finger tips controllers to the move_it configs because in the real arm, these joints are under-actuated and cannot be controlled.
**Pro** : the finger tips aren't falling anymore in Gazebo.
**Con** : a user can still send messages on the controllers's topics to change the finger tips's position individually. This cannot be done in a real arm, but it's the only way (besides a fixed joint) a joint can be controlled in Gazebo and not fall.