### PR TITLE
Add simulation torque sensing support in Gazebo

### DIFF
--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -60,9 +60,6 @@
         <axis xyz="${joint_axis_xyz}"/>
         <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
         <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
-        <sensor name="${joint_name}_torque_sensor" type="force_torque">
-          <update_rate>30</update_rate>
-        </sensor>
         <dynamics damping="0.0" friction="0.0"/>
      </joint>
    <xacro:unless value="${fixed}">

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -60,6 +60,9 @@
         <axis xyz="${joint_axis_xyz}"/>
         <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
         <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
+        <sensor name="${joint_name}_torque_sensor" type="force_torque">
+          <update_rate>30</update_rate>
+        </sensor>
         <dynamics damping="0.0" friction="0.0"/>
      </joint>
    <xacro:unless value="${fixed}">
@@ -73,6 +76,17 @@
         <mechanicalReduction>160</mechanicalReduction>
         </actuator>
      </transmission>
+     <!--For torque sensing in simulation-->
+     <gazebo reference="${joint_name}">
+        <provideFeedback>true</provideFeedback>
+      </gazebo>
+      <gazebo>
+        <plugin name="ft_sensor" filename="libgazebo_ros_ft_sensor.so">
+          <updateRate>30.0</updateRate>
+          <topicName>${joint_name}_ft_sensor_topic</topicName>
+          <jointName>${joint_name}</jointName>
+        </plugin>
+      </gazebo>
      </xacro:unless>
   </xacro:macro>
 


### PR DESCRIPTION
Adds support for wrench sensing in Gazebo, with [the ft_sensor_plugin](http://docs.ros.org/jade/api/gazebo_plugins/html/group__GazeboRosFTSensor.html).
Addresses #270 