### PR TITLE
Added C++11 to compile options for kinova_driver

### DIFF
--- a/kinova_driver/CMakeLists.txt
+++ b/kinova_driver/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kinova_driver)
+add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED dynamic_reconfigure COMPONENTS
   actionlib


### PR DESCRIPTION
Caused an error if compiled with gcc 5 without this option
Addresses #303 