### PR TITLE
driver: properly install the driver

### DIFF
--- a/kinova_driver/CMakeLists.txt
+++ b/kinova_driver/CMakeLists.txt
@@ -135,7 +135,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 ## Mark executables and/or libraries for installation
 install(TARGETS kinova_arm_driver kinova_tf_updater
-kinova_interactive_control
+kinova_interactive_control kinova_driver
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}


### PR DESCRIPTION
Installing kinova_driver is necessary to build kinova_demo in install
mode.