### PR TITLE
Use xacro instead of xacro.py

### DIFF
--- a/kinova_bringup/launch/kinova_robot.launch
+++ b/kinova_bringup/launch/kinova_robot.launch
@@ -27,7 +27,7 @@
   </group>
 
   <group if="$(arg use_urdf)">
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/$(arg kinova_robotType)_standalone.xacro'" />
+    <param name="robot_description" command="$(find xacro)/xacro '$(find kinova_description)/urdf/$(arg kinova_robotType)_standalone.xacro'" />
     <node name="$(arg kinova_robotName)_state_publisher"
            pkg="robot_state_publisher"
           type="robot_state_publisher">

--- a/kinova_description/launch/display_kinova_robot.launch
+++ b/kinova_description/launch/display_kinova_robot.launch
@@ -1,7 +1,7 @@
 <launch>
 	<arg name="gui" default="True" />
 	<arg name="kinova_robotType" default="j2n6s300" />
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/$(arg kinova_robotType)_standalone.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro '$(find kinova_description)/urdf/$(arg kinova_robotType)_standalone.xacro'" />
 	<param name="use_gui" value="$(arg gui)"/>
 	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
 		<param name="zeros/$(arg kinova_robotType)_joint_2" value="3.1415"/>

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/planning_context.launch
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/j2n6s300_standalone.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kinova_description)/urdf/j2n6s300_standalone.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find j2n6s300_moveit_config)/config/j2n6s300.srdf" />

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/planning_context.launch
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/j2s6s300_standalone.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kinova_description)/urdf/j2s6s300_standalone.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find j2s6s300_moveit_config)/config/j2s6s300.srdf" />

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/planning_context.launch
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/j2s7s300_standalone.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kinova_description)/urdf/j2s7s300_standalone.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find j2s7s300_moveit_config)/config/j2s7s300.srdf" />

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/planning_context.launch
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find kinova_description)/urdf/m1n6s300_standalone.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find kinova_description)/urdf/m1n6s300_standalone.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find m1n6s300_moveit_config)/config/m1n6s300.srdf" />


### PR DESCRIPTION
As documented in the wiki migration page for [noetic](https://wiki.ros.org/noetic/Migration#Use_xacro_instead_of_xacro.py).