### PR TITLE
Omit joint limits noetic

### DIFF
--- a/kinova_description/urdf/j2n6s200.xacro
+++ b/kinova_description/urdf/j2n6s200.xacro
@@ -132,7 +132,7 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" oint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>

--- a/kinova_description/urdf/j2n6s200.xacro
+++ b/kinova_description/urdf/j2n6s200.xacro
@@ -55,8 +55,6 @@
     <xacro:property name="joint_1_axis_xyz" value="0 0 1" />
     <xacro:property name="joint_1_origin_xyz" value="0 0 0.15675" />
     <xacro:property name="joint_1_origin_rpy" value="0 ${J_PI} 0" />
-    <xacro:property name="joint_1_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_1_upper_limit" value="${2*J_PI}" />
     <xacro:property name="joint_1_velocity_limit" value="${36*J_PI/180}" />
     <xacro:property name="joint_1_torque_limit" value="40" />
 
@@ -85,8 +83,6 @@
     <xacro:property name="joint_4_axis_xyz" value="0 0 1" />
     <xacro:property name="joint_4_origin_xyz" value="0 0.2073 -0.0114" />
     <xacro:property name="joint_4_origin_rpy" value="-${J_PI/2} 0 ${J_PI}" />
-    <xacro:property name="joint_4_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_4_upper_limit" value="${2*J_PI}" />
     <xacro:property name="joint_4_velocity_limit" value="${48*J_PI/180}" />
     <xacro:property name="joint_4_torque_limit" value="20" />
 
@@ -95,8 +91,6 @@
     <xacro:property name="joint_5_axis_xyz" value="0 0 1" />
     <xacro:property name="joint_5_origin_xyz" value="0 -0.03703 -0.06414" />
     <xacro:property name="joint_5_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
-    <xacro:property name="joint_5_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_5_upper_limit" value="${2*J_PI}" />
     <xacro:property name="joint_5_velocity_limit" value="${48*J_PI/180}" />
     <xacro:property name="joint_5_torque_limit" value="20" />
 
@@ -107,8 +101,6 @@
     <xacro:property name="joint_6_origin_rpy" value="${J_PI/3} 0 ${J_PI}" />
     <!-- If gripper inverted, use this line instead -->
     <!-- <xacro:property name="joint_6_origin_rpy" value="$${-J_PI/3} 0 0" /> -->
-    <xacro:property name="joint_6_lower_limit" value="${-2*J_PI}" />
-    <xacro:property name="joint_6_upper_limit" value="${2*J_PI}" />
     <xacro:property name="joint_6_velocity_limit" value="${48*J_PI/180}" />
     <xacro:property name="joint_6_torque_limit" value="20" />
 
@@ -125,10 +117,10 @@
         <xacro:gazebo_config robot_namespace="${prefix}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_base" link_mesh="${link_base_mesh}" mesh_no="${link_base_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0" joint_velocity_limit="0" joint_torque_limit="0" fixed="true"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_base" type="${joint_base_type}" parent="${base_parent}" child="${prefix}_link_base" joint_axis_xyz="${joint_base_axis_xyz}" joint_origin_xyz="${joint_base_origin_xyz}" joint_origin_rpy="${joint_base_origin_rpy}" fixed="true"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_1" link_mesh="${link_1_mesh}" use_ring_mesh="true" mesh_no="${link_1_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_lower_limit="${joint_1_lower_limit}" joint_upper_limit="${joint_1_upper_limit}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_1" type="${joint_1_type}" parent="${prefix}_link_base" child="${prefix}_link_1" joint_axis_xyz="${joint_1_axis_xyz}" joint_origin_xyz="${joint_1_origin_xyz}" joint_origin_rpy="${joint_1_origin_rpy}" joint_velocity_limit="${joint_1_velocity_limit}" joint_torque_limit="${joint_1_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_2" link_mesh="${link_2_mesh}" use_ring_mesh="true" mesh_no="${link_2_mesh_no}"/>
         <xacro:kinova_armjoint joint_name="${prefix}_joint_2" type="${joint_2_type}" parent="${prefix}_link_1" child="${prefix}_link_2" joint_axis_xyz="${joint_2_axis_xyz}" joint_origin_xyz="${joint_2_origin_xyz}" joint_origin_rpy="${joint_2_origin_rpy}" joint_lower_limit="${joint_2_lower_limit}" joint_upper_limit="${joint_2_upper_limit}" joint_velocity_limit="${joint_2_velocity_limit}" joint_torque_limit="${joint_2_torque_limit}"/>
@@ -137,13 +129,13 @@
         <xacro:kinova_armjoint joint_name="${prefix}_joint_3" type="${joint_3_type}" parent="${prefix}_link_2" child="${prefix}_link_3" joint_axis_xyz="${joint_3_axis_xyz}" joint_origin_xyz="${joint_3_origin_xyz}" joint_origin_rpy="${joint_3_origin_rpy}" joint_lower_limit="${joint_3_lower_limit}" joint_upper_limit="${joint_3_upper_limit}" joint_velocity_limit="${joint_3_velocity_limit}" joint_torque_limit="${joint_3_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_4" link_mesh="${link_4_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_4_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_lower_limit="${joint_4_lower_limit}" joint_upper_limit="${joint_4_upper_limit}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_4" type="${joint_4_type}" parent="${prefix}_link_3" child="${prefix}_link_4" joint_axis_xyz="${joint_4_axis_xyz}" joint_origin_xyz="${joint_4_origin_xyz}" joint_origin_rpy="${joint_4_origin_rpy}" joint_velocity_limit="${joint_4_velocity_limit}" joint_torque_limit="${joint_4_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_5" link_mesh="${link_5_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_5_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" joint_lower_limit="${joint_5_lower_limit}" joint_upper_limit="${joint_5_upper_limit}" joint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_5" type="${joint_5_type}" parent="${prefix}_link_4" child="${prefix}_link_5" joint_axis_xyz="${joint_5_axis_xyz}" joint_origin_xyz="${joint_5_origin_xyz}" joint_origin_rpy="${joint_5_origin_rpy}" oint_velocity_limit="${joint_5_velocity_limit}" joint_torque_limit="${joint_5_torque_limit}"/>
 
         <xacro:kinova_armlink link_name="${prefix}_link_6" link_mesh="${link_6_mesh}" use_ring_mesh="true" ring_mesh="ring_small" mesh_no="${link_6_mesh_no}"/>
-        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_lower_limit="${joint_6_lower_limit}" joint_upper_limit="${joint_6_upper_limit}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
+        <xacro:kinova_armjoint joint_name="${prefix}_joint_6" type="${joint_6_type}" parent="${prefix}_link_5" child="${prefix}_link_6" joint_axis_xyz="${joint_6_axis_xyz}" joint_origin_xyz="${joint_6_origin_xyz}" joint_origin_rpy="${joint_6_origin_rpy}" joint_velocity_limit="${joint_6_velocity_limit}" joint_torque_limit="${joint_6_torque_limit}"/>
 
 
         <xacro:kinova_virtual_link link_name="${prefix}_end_effector"/>

--- a/kinova_description/urdf/kinova_common.xacro
+++ b/kinova_description/urdf/kinova_common.xacro
@@ -53,12 +53,46 @@
 
     </xacro:macro>
 
-  <xacro:macro name="kinova_armjoint" params="joint_name type parent child joint_axis_xyz joint_origin_xyz joint_origin_rpy joint_lower_limit joint_upper_limit joint_velocity_limit joint_torque_limit fixed:=false">
+  <!--
+    We use dummy default values for values only required when type=='revolute':
+    joint_lower_limit and joint_upper_limit (set to 1234567890)
+    We check during macro execution that these values have been set properly if
+    the joint type requires it (revolute).
+    Similarly, we check that velocity and torque limits are set unless the joint
+    type is fixed, and that the fixed parameter is set consistently.
+  -->
+  <xacro:property name="dummy_default_value" value="1234567890"/>
+  <xacro:macro name="kinova_armjoint" params="joint_name
+                                              type
+                                              parent
+                                              child
+                                              joint_axis_xyz
+                                              joint_origin_xyz
+                                              joint_origin_rpy
+                                              joint_lower_limit:=${dummy_default_value}
+                                              joint_upper_limit:=${dummy_default_value}
+                                              joint_velocity_limit:=${dummy_default_value}
+                                              joint_torque_limit:=${dummy_default_value}
+                                              fixed:=false">
+    <xacro:if value="${(type == 'fixed' and not fixed) or (type != 'fixed' and fixed)}"><xacro:ERROR_inconsistent_joint_type_specification/></xacro:if>
+    <xacro:if value="${type == 'revolute'}">
+      <xacro:if value="${joint_lower_limit == dummy_default_value}"><xacro:ERROR_joint_lower_limit_needs_to_be_set_for_a_revolute_joint/></xacro:if>
+      <xacro:if value="${joint_upper_limit == dummy_default_value}"><xacro:ERROR_joint_upper_limit_needs_to_be_set_for_a_revolute_joint/></xacro:if>
+    </xacro:if>
+    <xacro:unless value="${type =='fixed'}">
+      <xacro:if value="${joint_velocity_limit == dummy_default_value}"><xacro:ERROR_joint_velocity_limit_needs_to_be_set_for_a_non_fixed_joint/></xacro:if>
+      <xacro:if value="${joint_torque_limit == dummy_default_value}"><xacro:ERROR_joint_torque_limit_needs_to_be_set_for_a_non_fixed_joint/></xacro:if>
+    </xacro:unless>
     <joint name="${joint_name}" type="${type}">
         <parent link="${parent}"/>
         <child link="${child}"/>
         <axis xyz="${joint_axis_xyz}"/>
+        <xacro:if value="${type == 'revolute'}">
         <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
+        </xacro:if>
+        <xacro:if value="${type == 'continuous'}">
+        <limit effort="${joint_torque_limit}" velocity="${joint_velocity_limit}"/>
+        </xacro:if>
         <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
         <dynamics damping="0.0" friction="0.0"/>
      </joint>
@@ -97,7 +131,9 @@
         <parent link="${parent}"/>
         <child link="${child}"/>
         <axis xyz="${joint_axis_xyz}"/>
+        <xacro:unless value="${type == 'fixed'}">
         <limit effort="2000" velocity="1" lower="${joint_lower_limit}" upper="${joint_upper_limit}"/>
+        </xacro:unless>
         <origin xyz="${joint_origin_xyz}" rpy="${joint_origin_rpy}"/>
      </joint>
     </xacro:macro>


### PR DESCRIPTION
From #347 
- add logic in kinova_armjoint macro to allow continous joints to be used without lower and upper limits
- add logic in kinova_armjoint macro to allow fixed joints to be used without lower, upper, velocity and torque limits
- removed continuous joint limits for the j2n6s200 has a "proof of concept" (limits for other robots could be removed in a further PR) 