### PR TITLE
add argument to select different moveit controller manager with gazebo

### DIFF
--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/j2n6s300_gazebo_demo.launch
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/j2n6s300_gazebo_demo.launch
@@ -25,7 +25,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="joint_states_ns" value="/j2n6s300/joint_states"/>
-    <arg name="controller_manager" value="j2n6s300_ros_control"/>
+    <arg name="gazebo_sim" value="true"/>
   </include>  
 
   <!-- ros-control Controller parameters-->  

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/j2n6s300_moveit_controller_manager.launch.xml
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/j2n6s300_moveit_controller_manager.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fake_execution" default="false"/>
+  <arg name="gazebo_sim" default="false"/>
 
 <!-- Fake Arm -->
   <group if="$(arg fake_execution)">
@@ -16,6 +17,7 @@
     <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
 
     <!-- The rest of the params are specific to this plugin -->
-    <rosparam file="$(find j2n6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam unless="$(arg gazebo_sim)" file="$(find j2n6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam if="$(arg gazebo_sim)" file="$(find j2n6s300_moveit_config)/config/controllers_ros_control.yaml"/>
   </group>
 </launch>

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group_j2n6s300.launch
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/move_group_j2n6s300.launch
@@ -20,6 +20,7 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
   <arg name="joint_states_ns" default="/j2n6s300_driver/out/joint_state"/>
+  <arg name="gazebo_sim" default="false"/>
 
   <!-- Planning Functionality -->
   <include ns="move_group" file="$(find j2n6s300_moveit_config)/launch/planning_pipeline.launch.xml">
@@ -30,6 +31,7 @@
   <include ns="move_group" file="$(find j2n6s300_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
   <!-- Sensors Functionality -->

--- a/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/trajectory_execution.launch.xml
+++ b/kinova_moveit/robot_configs/j2n6s300_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,8 +13,10 @@
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="fake_execution" default="false" />
+  <arg name="gazebo_sim" default="false"/>
   <include file="$(find j2n6s300_moveit_config)/launch/j2n6s300_moveit_controller_manager.launch.xml">
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
   
 </launch>

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/j2s6s300_gazebo_demo.launch
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/j2s6s300_gazebo_demo.launch
@@ -25,7 +25,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="joint_states_ns" value="/j2s6s300/joint_states"/>
-    <arg name="controller_manager" value="j2s6s300_ros_control"/>
+    <arg name="gazebo_sim" value="true"/>
   </include>  
 
   <!-- ros-control Controller parameters-->  

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/j2s6s300_moveit_controller_manager.launch.xml
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/j2s6s300_moveit_controller_manager.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fake_execution" default="false"/>
+  <arg name="gazebo_sim" default="false"/>
 
 <!-- Fake Arm -->
   <group if="$(arg fake_execution)">
@@ -16,6 +17,7 @@
     <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
 
     <!-- The rest of the params are specific to this plugin -->
-    <rosparam file="$(find j2s6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam unless="$(arg gazebo_sim)" file="$(find j2s6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam if="$(arg gazebo_sim)" file="$(find j2s6s300_moveit_config)/config/controllers_ros_control.yaml"/>
   </group>
 </launch>

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/move_group_j2s6s300.launch
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/move_group_j2s6s300.launch
@@ -20,6 +20,7 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
   <arg name="joint_states_ns" default="/j2s6s300_driver/out/joint_state"/>
+  <arg name="gazebo_sim" default="false"/>
 
   <!-- Planning Functionality -->
   <include ns="move_group" file="$(find j2s6s300_moveit_config)/launch/planning_pipeline.launch.xml">
@@ -30,7 +31,7 @@
   <include ns="move_group" file="$(find j2s6s300_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="fake_execution" value="$(arg fake_execution)"/>
-    
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
   <!-- Sensors Functionality -->

--- a/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/trajectory_execution.launch.xml
+++ b/kinova_moveit/robot_configs/j2s6s300_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,8 +13,10 @@
 
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="fake_execution" default="false" />
+  <arg name="gazebo_sim" default="false"/>
   <include file="$(find j2s6s300_moveit_config)/launch/j2s6s300_moveit_controller_manager.launch.xml">
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
 </launch>

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/j2s7s300_gazebo_demo.launch
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/j2s7s300_gazebo_demo.launch
@@ -25,7 +25,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="joint_states_ns" value="/j2s7s300/joint_states"/>
-    <arg name="controller_manager" value="j2s7s300_ros_control"/>
+    <arg name="gazebo_sim" value="true"/>
   </include>  
 
   <!-- ros-control Controller parameters-->  

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/j2s7s300_moveit_controller_manager.launch.xml
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/j2s7s300_moveit_controller_manager.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fake_execution" default="false"/>
+  <arg name="gazebo_sim" default="false"/>
 
 <!-- Fake Arm -->
   <group if="$(arg fake_execution)">
@@ -16,6 +17,7 @@
     <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
 
     <!-- The rest of the params are specific to this plugin -->
-    <rosparam file="$(find j2s7s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam unless="$(arg gazebo_sim)" file="$(find j2s7s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam if="$(arg gazebo_sim)" file="$(find j2s7s300_moveit_config)/config/controllers_ros_control.yaml"/>
   </group>
 </launch>

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group_j2s7s300.launch
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/move_group_j2s7s300.launch
@@ -20,6 +20,7 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
   <arg name="joint_states_ns" default="/j2s6s300_driver/out/joint_state"/>
+  <arg name="gazebo_sim" default="false"/>
 
   <!-- Planning Functionality -->
   <include ns="move_group" file="$(find j2s7s300_moveit_config)/launch/planning_pipeline.launch.xml">
@@ -30,6 +31,7 @@
   <include ns="move_group" file="$(find j2s7s300_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
   <!-- Sensors Functionality -->

--- a/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/trajectory_execution.launch.xml
+++ b/kinova_moveit/robot_configs/j2s7s300_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,8 +13,10 @@
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="fake_execution" default="false" />
+  <arg name="gazebo_sim" default="false"/>
   <include file="$(find j2s7s300_moveit_config)/launch/j2s7s300_moveit_controller_manager.launch.xml">
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
   
 </launch>

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/m1n6s300_demo.launch
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/m1n6s300_demo.launch
@@ -32,6 +32,7 @@
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="joint_states_ns" value="/m1n6s300_driver/out/joint_state"/> 
+    <arg name="gazebo_sim" value="true"/>
   </include>
 
   <!-- kinova-driver Controller parameters-->   

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/m1n6s300_moveit_controller_manager.launch.xml
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/m1n6s300_moveit_controller_manager.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <arg name="fake_execution" default="false"/>
+  <arg name="gazebo_sim" default="false"/>
 
 <!-- Fake Arm -->
   <group if="$(arg fake_execution)">
@@ -16,6 +17,7 @@
     <param name="moveit_controller_manager" value="moveit_simple_controller_manager/MoveItSimpleControllerManager"/>
 
     <!-- The rest of the params are specific to this plugin -->
-    <rosparam file="$(find m1n6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam unless="$(arg gazebo_sim)" file="$(find m1n6s300_moveit_config)/config/controllers.yaml"/>
+    <rosparam if="$(arg gazebo_sim)" file="$(find m1n6s300_moveit_config)/config/controllers_ros_control.yaml"/>
   </group>
 </launch>

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group_m1n6s300.launch
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/move_group_m1n6s300.launch
@@ -20,6 +20,7 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
   <arg name="joint_states_ns" default="/m1n6s300_driver/out/joint_state"/>
+  <arg name="gazebo_sim" default="false"/>
 
   <!-- Planning Functionality -->
   <include ns="move_group" file="$(find m1n6s300_moveit_config)/launch/planning_pipeline.launch.xml">
@@ -30,6 +31,7 @@
   <include ns="move_group" file="$(find m1n6s300_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
     <arg name="moveit_manage_controllers" value="true" />
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
   <!-- Sensors Functionality -->

--- a/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/trajectory_execution.launch.xml
+++ b/kinova_moveit/robot_configs/m1n6s300_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,8 +13,10 @@
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="fake_execution" default="false" />
+  <arg name="gazebo_sim" default="false"/>
   <include file="$(find m1n6s300_moveit_config)/launch/m1n6s300_moveit_controller_manager.launch.xml">
     <arg name="fake_execution" value="$(arg fake_execution)"/>
+    <arg name="gazebo_sim" value="$(arg gazebo_sim)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
Some launch files modification from #340 prevents from using moveit in a Gazebo simulation for the Noetic branch. 

Added an argument to select the correct moveit control manager file when using a Gazebo simulation