### PR TITLE
Bugfix: Invalid check of serial number

### DIFF
--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -132,7 +132,7 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle,
 
     bool found_arm = false;
     for (int device_i = 0; device_i < devices_count; device_i++)
-        {
+    {
         // If no device is specified, just use the first available device
         if (serial_number == "" || serial_number == "not_set" ||
             std::strncmp(serial_number.c_str(),

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -130,17 +130,6 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle,
         throw KinovaCommException("Could not get devices list count.", result);
     }
 
-    // DEBUG
-    for (int device_i = 0; device_i < devices_count; device_i++)
-    {
-        ROS_INFO_STREAM("Device: " << device_i << ", SerialNumber: "
-            << devices_list_[device_i].SerialNumber << ", strcmp: "
-            << std::strncmp(serial_number.c_str(),
-            devices_list_[device_i].SerialNumber,
-            strlen(devices_list_[device_i].SerialNumber)-1));
-    }
-    ROS_INFO_STREAM("Given serial number:     " << serial_number.c_str() << ".");
-
     bool found_arm = false;
     for (int device_i = 0; device_i < devices_count; device_i++)
         {
@@ -148,7 +137,7 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle,
         if (serial_number == "" || serial_number == "not_set" ||
             std::strncmp(serial_number.c_str(),
                          devices_list_[device_i].SerialNumber,
-                         strlen(devices_list_[device_i].SerialNumber)-1) == 0) // Exculde trailing whitespace of device serial number from check
+                         strlen(devices_list_[device_i].SerialNumber)-1) == 0)
         {
             result = kinova_api_.setActiveDevice(devices_list_[device_i]);
             if (result != NO_ERROR_KINOVA)

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -137,7 +137,9 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle,
         if (serial_number == "" || serial_number == "not_set" ||
             std::strncmp(serial_number.c_str(),
                          devices_list_[device_i].SerialNumber,
-                         strlen(devices_list_[device_i].SerialNumber)-1) == 0)
+                         std::min(serial_number.length(), 
+                                  strlen(devices_list_[device_i].SerialNumber))) 
+            == 0)
         {
             result = kinova_api_.setActiveDevice(devices_list_[device_i]);
             if (result != NO_ERROR_KINOVA)

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -130,12 +130,25 @@ KinovaComm::KinovaComm(const ros::NodeHandle& node_handle,
         throw KinovaCommException("Could not get devices list count.", result);
     }
 
-    bool found_arm = false;
+    // DEBUG
     for (int device_i = 0; device_i < devices_count; device_i++)
     {
+        ROS_INFO_STREAM("Device: " << device_i << ", SerialNumber: "
+            << devices_list_[device_i].SerialNumber << ", strcmp: "
+            << std::strncmp(serial_number.c_str(),
+            devices_list_[device_i].SerialNumber,
+            strlen(devices_list_[device_i].SerialNumber)-1));
+    }
+    ROS_INFO_STREAM("Given serial number:     " << serial_number.c_str() << ".");
+
+    bool found_arm = false;
+    for (int device_i = 0; device_i < devices_count; device_i++)
+        {
         // If no device is specified, just use the first available device
         if (serial_number == "" || serial_number == "not_set" ||
-            std::strcmp(serial_number.c_str(), devices_list_[device_i].SerialNumber) == 0)
+            std::strncmp(serial_number.c_str(),
+                         devices_list_[device_i].SerialNumber,
+                         strlen(devices_list_[device_i].SerialNumber)-1) == 0) // Exculde trailing whitespace of device serial number from check
         {
             result = kinova_api_.setActiveDevice(devices_list_[device_i]);
             if (result != NO_ERROR_KINOVA)
@@ -1457,36 +1470,36 @@ void KinovaComm::setFingerPositions(const FingerAngles &fingers, int timeout, bo
 	{
 		kinova_point.Position.Type = CARTESIAN_POSITION;
 		CartesianPosition pose;
-                memset(&pose, 0, sizeof(pose));  // zero structure   
+                memset(&pose, 0, sizeof(pose));  // zero structure
 		result = kinova_api_.getCartesianCommand(pose);
     		if (result != NO_ERROR_KINOVA)
     		{
         		throw KinovaCommException("Could not get the Cartesian position", result);
-    		}    
+    		}
 		kinova_point.Position.CartesianPosition=pose.Coordinates;
 	}
         else if(control_type==1) //angular
-	{	
-		kinova_point.Position.Type = ANGULAR_POSITION;	
+	{
+		kinova_point.Position.Type = ANGULAR_POSITION;
 		AngularPosition joint_angles;
-    		memset(&joint_angles, 0, sizeof(joint_angles));  // zero structure    
+    		memset(&joint_angles, 0, sizeof(joint_angles));  // zero structure
 		result = kinova_api_.getAngularCommand(joint_angles);
     		if (result != NO_ERROR_KINOVA)
     		{
         		throw KinovaCommException("Could not get the angular position", result);
-    		}    
+    		}
 		kinova_point.Position.Actuators = joint_angles.Actuators;
 	}
 	else
-	{ 
+	{
 		throw KinovaCommException("Wrong control type", result);
-	}  
+	}
     }
-     
+
 
     // getAngularPosition will cause arm drop
     // result = kinova_api_.getAngularPosition(joint_angles);
-       
+
     result = kinova_api_.sendBasicTrajectory(kinova_point);
     if (result != NO_ERROR_KINOVA)
     {


### PR DESCRIPTION
The serial numbers of the robot(s) in `devices_list_` contain a trailing white space, such that the string comparison with the serial number, given from a ROS parameter, fails even if the serial number is correct. 
Therefore, the trailing white space is ignored by using `strncmp` to ensure the correct check of the serial number. 