### PR TITLE
Joint Trajectory Controller Improvements

### DIFF
--- a/kinova_driver/include/kinova/KinovaTypes.h
+++ b/kinova_driver/include/kinova/KinovaTypes.h
@@ -468,6 +468,31 @@ struct AngularInfo
 		Actuator6 = 0.0f;
 		Actuator7 = 0.0f;
 	}
+
+	float& operator [](const int idx){
+		switch (idx)
+		{
+			case 0: return Actuator1;
+			case 1: return Actuator2;
+			case 2: return Actuator3;
+			case 3: return Actuator4;
+			case 4: return Actuator5;
+			case 5: return Actuator6;
+			case 6: return Actuator7;
+		}
+	}
+    float operator [](const int idx) const{
+		switch (idx)
+		{
+			case 0: return Actuator1;
+			case 1: return Actuator2;
+			case 2: return Actuator3;
+			case 3: return Actuator4;
+			case 4: return Actuator5;
+			case 5: return Actuator6;
+			case 6: return Actuator7;
+		}
+	}
 };
 
 /** @brief This data structure holds values in an cartesian control context.

--- a/kinova_driver/include/kinova_driver/kinova_arm.h
+++ b/kinova_driver/include/kinova_driver/kinova_arm.h
@@ -18,6 +18,7 @@
 #include <tf/tf.h>
 #include <tf/transform_listener.h>
 #include <sensor_msgs/JointState.h>
+#include <std_srvs/Trigger.h>
 
 #include <kinova_msgs/Stop.h>
 #include <kinova_msgs/Start.h>
@@ -78,6 +79,8 @@ class KinovaArm
     // Service callbacks -----------------------------------------------------------
     bool stopServiceCallback(kinova_msgs::Stop::Request &req, kinova_msgs::Stop::Response &res);
     bool startServiceCallback(kinova_msgs::Start::Request &req, kinova_msgs::Start::Response &res);
+    bool cartesian_controlServiceCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
+    bool angular_controlServiceCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res);
     bool homeArmServiceCallback(kinova_msgs::HomeArm::Request &req, kinova_msgs::HomeArm::Response &res);
     bool ActivateNullSpaceModeCallback(kinova_msgs::SetNullSpaceModeState::Request &req,
                                        kinova_msgs::SetNullSpaceModeState::Response &res);
@@ -141,6 +144,8 @@ class KinovaArm
 
     ros::ServiceServer stop_service_;
     ros::ServiceServer start_service_;
+    ros::ServiceServer cartesian_control_service_;
+    ros::ServiceServer angular_control_service_;
     ros::ServiceServer homing_service_;
     ros::ServiceServer start_null_space_service_;
     ros::ServiceServer add_trajectory_;

--- a/kinova_driver/include/kinova_driver/kinova_arm.h
+++ b/kinova_driver/include/kinova_driver/kinova_arm.h
@@ -18,6 +18,7 @@
 #include <tf/tf.h>
 #include <tf/transform_listener.h>
 #include <sensor_msgs/JointState.h>
+#include <sensor_msgs/Joy.h>
 #include <std_srvs/Trigger.h>
 
 #include <kinova_msgs/Stop.h>
@@ -119,6 +120,7 @@ class KinovaArm
     void publishToolPosition(void);
     void publishToolWrench(void);
     void publishFingerPosition(void);
+    void publishJoystickCommand(void);
 
     tf::TransformListener tf_listener_;
     ros::NodeHandle node_handle_;
@@ -138,6 +140,7 @@ class KinovaArm
     ros::Publisher tool_wrench_publisher_;
     ros::Publisher finger_position_publisher_;
     ros::Publisher joint_state_publisher_;
+    ros::Publisher joystick_command_publisher_;
 
     ros::Publisher joint_command_publisher_;
     ros::Publisher cartesian_command_publisher_;

--- a/kinova_driver/include/kinova_driver/kinova_comm.h
+++ b/kinova_driver/include/kinova_driver/kinova_comm.h
@@ -88,6 +88,7 @@ class KinovaComm
     void initFingers(void);
     void setEndEffectorOffset(unsigned int status, float x, float y, float z);
     void getEndEffectorOffset(unsigned int &status, float &x, float &y, float &z);
+    void getJoystickCommand(JoystickCommand &joystick_command);
 
     // %EndTag(general functions)
 

--- a/kinova_driver/include/kinova_driver/kinova_joint_trajectory_controller.h
+++ b/kinova_driver/include/kinova_driver/kinova_joint_trajectory_controller.h
@@ -1,7 +1,6 @@
 #ifndef KINOVA_JOINT_TRAJECTORY_CONTROLLER_H
 #define KINOVA_JOINT_TRAJECTORY_CONTROLLER_H
 
-
 #include <ros/ros.h>
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <sensor_msgs/JointState.h>
@@ -26,46 +25,33 @@ public:
 private:
     ros::NodeHandle nh_;
 
-    ros::Subscriber sub_command_;
-    ros::Publisher pub_joint_feedback_;
-    ros::Publisher pub_joint_velocity_;
+    ros::Subscriber sub_command_; // command subscriber listening to 'trajectory_controller/command'
+    ros::Publisher pub_joint_feedback_; // feedback publisher sending to 'trajectory_controller/state'
+    ros::Publisher pub_joint_velocity_; // velocity publisher sending to 'in/joint_velocity'
 
-    ros::Time previous_pub_;
-    ros::Time time_pub_joint_vel_;
+    ros::Time time_pub_joint_vel_; // time of timer thread start to publish joint velocity command
 
-    ros::Timer timer_pub_joint_vel_;
+    ros::Timer timer_pub_joint_vel_; // timer to publish joint velocities
     boost::mutex terminate_thread_mutex_;
     boost::thread* thread_update_state_;
     bool terminate_thread_;
 
-    std_msgs::Duration time_from_start_;
-    sensor_msgs::JointState current_joint_state_;
+    KinovaComm kinova_comm_; // Communication pipeline for the arm
 
-    KinovaComm kinova_comm_;
-    TrajectoryPoint kinova_traj_point_;
-
-//    trajectory_msgs::JointTrajectory joint_traj_;
-//    trajectory_msgs::JointTrajectoryPoint joint_traj_point_;
-    std::string traj_frame_id_;
-    std::vector<trajectory_msgs::JointTrajectoryPoint> traj_command_points_;
-    control_msgs::FollowJointTrajectoryFeedback traj_feedback_msg_;
+    std::string traj_frame_id_; // origin of trajectory transforms
+    std::vector<trajectory_msgs::JointTrajectoryPoint> traj_command_points_; // trajectory points from most recent trajectory
+    control_msgs::FollowJointTrajectoryFeedback traj_feedback_msg_; // trajectory feedback message
 
     // stores the command to send to robot, in Kinova type (KinovaAngles)
-    std::vector<KinovaAngles> kinova_angle_command_;
+    std::vector<KinovaAngles> kinova_angle_command_; // intermediate command storage
 
-    uint number_joint_;
-    int traj_command_points_index_;
-    std::vector<std::string> joint_names_;
-    std::string prefix_;
-
-    struct Segment
-    {
-        double start_time;
-        double duration;
-        std::vector<double> positions;
-        std::vector<double> velocities;
-    };
-
+    uint number_joint_; // number of joints of the robot
+    int traj_command_points_index_; // current index in traj_command_points_, defined by time
+    std::vector<std::string> joint_names_; // names of the joints
+    std::string prefix_; // robot name prefix
+    const static int num_possible_joints = 7; // number of possible joints supported by the system
+    float current_velocity_command[num_possible_joints]; // storage array to keep calculated velocity commands
+    double remaining_motion_time[num_possible_joints]; // time of motion remaining for each joint during the last command
 
     // call back function when receive a trajectory command
     void commandCB(const trajectory_msgs::JointTrajectoryConstPtr &traj_msg);
@@ -73,17 +59,11 @@ private:
     // reflash the robot state and publish the joint state: either by timer or thread
     void update_state(); // by thread
 
+    // regularly publish the velocity commands of the trajectory 
     void pub_joint_vel(const ros::TimerEvent&); // by timer
-    int test;
 
 };
 
-
-
-
-
-
 }
-
 
 #endif // KINOVA_JOINT_TRAJECTORY_CONTROLLER_H

--- a/kinova_driver/src/kinova_arm.cpp
+++ b/kinova_driver/src/kinova_arm.cpp
@@ -165,7 +165,7 @@ KinovaArm::KinovaArm(KinovaComm &arm, const ros::NodeHandle &nodeHandle, const s
     /* Set up Services */
     stop_service_ = node_handle_.advertiseService("in/stop", &KinovaArm::stopServiceCallback, this);
     start_service_ = node_handle_.advertiseService("in/start", &KinovaArm::startServiceCallback, this);
-    cartesian_control_service_ = node_handle_.advertiseService("in/cartesian_control", &KinovaArm::angular_controlServiceCallback, this);
+    cartesian_control_service_ = node_handle_.advertiseService("in/cartesian_control", &KinovaArm::cartesian_controlServiceCallback, this);
     angular_control_service_ = node_handle_.advertiseService("in/angular_control", &KinovaArm::angular_controlServiceCallback, this);
     homing_service_ = node_handle_.advertiseService("in/home_arm", &KinovaArm::homeArmServiceCallback, this);
     add_trajectory_ = node_handle_.advertiseService("in/add_pose_to_Cartesian_trajectory",
@@ -385,6 +385,7 @@ bool KinovaArm::cartesian_controlServiceCallback(std_srvs::Trigger::Request &req
     ROS_DEBUG("Cartesian Control requested");
     return true;
 }
+
 /*
  * Handler for service to change to angular control mode.
  */
@@ -396,8 +397,6 @@ bool KinovaArm::angular_controlServiceCallback(std_srvs::Trigger::Request &req, 
     ROS_DEBUG("Angular Control requested");
     return true;
 }
-
-
 
 /*!
  * \brief Handler for "start" service.

--- a/kinova_driver/src/kinova_arm.cpp
+++ b/kinova_driver/src/kinova_arm.cpp
@@ -165,6 +165,8 @@ KinovaArm::KinovaArm(KinovaComm &arm, const ros::NodeHandle &nodeHandle, const s
     /* Set up Services */
     stop_service_ = node_handle_.advertiseService("in/stop", &KinovaArm::stopServiceCallback, this);
     start_service_ = node_handle_.advertiseService("in/start", &KinovaArm::startServiceCallback, this);
+    cartesian_control_service_ = node_handle_.advertiseService("in/cartesian_control", &KinovaArm::angular_controlServiceCallback, this);
+    angular_control_service_ = node_handle_.advertiseService("in/angular_control", &KinovaArm::angular_controlServiceCallback, this);
     homing_service_ = node_handle_.advertiseService("in/home_arm", &KinovaArm::homeArmServiceCallback, this);
     add_trajectory_ = node_handle_.advertiseService("in/add_pose_to_Cartesian_trajectory",
                       &KinovaArm::addCartesianPoseToTrajectory, this);
@@ -369,6 +371,30 @@ bool KinovaArm::stopServiceCallback(kinova_msgs::Stop::Request &req, kinova_msgs
     ROS_DEBUG("Arm stop requested");
     return true;
 }
+
+/*
+ * Handler for service to change to cartesian control mode.
+ */
+bool KinovaArm::cartesian_controlServiceCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+{
+    kinova_comm_.setCartesianControl();
+    res.message = "Cartesian Control activated";
+    res.success = true;
+    ROS_DEBUG("Cartesian Control requested");
+    return true;
+}
+/*
+ * Handler for service to change to angular control mode.
+ */
+bool KinovaArm::angular_controlServiceCallback(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+{
+    kinova_comm_.setAngularControl();
+    res.message  = "Angular Control activated";
+    res.success = true;
+    ROS_DEBUG("Angular Control requested");
+    return true;
+}
+
 
 
 /*!

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -419,6 +419,21 @@ void KinovaComm::getControlType(int &controlType)
     }
 }
 
+/**
+ * Requests the current joystick command from the robotical arm
+ * Warning: There might be an issue with the ButtonValue Attribute
+ *          Our tests show them to be a byte array with an initial offset of 4 bytes
+ */
+void KinovaComm::getJoystickCommand(JoystickCommand &joystick_command)
+{
+    boost::recursive_mutex::scoped_lock lock(api_mutex_);
+    int result = kinova_api_.getJoystickValue(joystick_command);
+    if (result!=NO_ERROR_KINOVA)
+    {
+        throw KinovaCommException("Could not get joystick command", result);
+    }
+}
+
 
 /**
  * @brief get almost all information of the robotical arm.

--- a/kinova_driver/src/kinova_comm.cpp
+++ b/kinova_driver/src/kinova_comm.cpp
@@ -973,7 +973,6 @@ void KinovaComm::setCartesianControl()
         return;
     }
     int result = kinova_api_.setCartesianControl();
-    ROS_WARN("%d", result);
     if (result != NO_ERROR_KINOVA)
     {
         throw KinovaCommException("Could not set Cartesian control", result);

--- a/kinova_driver/src/kinova_joint_trajectory_controller.cpp
+++ b/kinova_driver/src/kinova_joint_trajectory_controller.cpp
@@ -8,33 +8,23 @@ JointTrajectoryController::JointTrajectoryController(kinova::KinovaComm &kinova_
     kinova_comm_(kinova_comm),
     nh_(n)
 {
-    //ROS_DEBUG_STREAM_ONCE("Get in: " << __PRETTY_FUNCTION__);
-
     ros::NodeHandle pn("~");
     std::string robot_type;
     nh_.param<std::string>("robot_name",prefix_,"j2n6s300");
     nh_.param<std::string>("robot_type",robot_type,"j2n6s300");
     number_joint_ =robot_type[3] - '0';
 
-    // Display debug information in teminal
-    if( ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug) ) {
-        ros::console::notifyLoggerLevelsChanged();
-    }
-
     sub_command_ = nh_.subscribe("trajectory_controller/command", 1, &JointTrajectoryController::commandCB, this);
 
     pub_joint_feedback_ = nh_.advertise<control_msgs::FollowJointTrajectoryFeedback>("trajectory_controller/state", 1);
     pub_joint_velocity_ = pn.advertise<kinova_msgs::JointVelocity>("in/joint_velocity", 2);
 
-    traj_frame_id_ = "root";   
+    traj_frame_id_ = "root";
     joint_names_.resize(number_joint_);
-    //std::cout << "joint names in feedback of trajectory state are: " << std::endl;
     for (uint i = 0; i<joint_names_.size(); i++)
     {
         joint_names_[i] = prefix_ + "_joint_" + boost::lexical_cast<std::string>(i+1);
-        std::cout << joint_names_[i] << " ";
     }
-    std::cout << std::endl;
 
     timer_pub_joint_vel_ = nh_.createTimer(ros::Duration(0.01), &JointTrajectoryController::pub_joint_vel, this, false, false);
     terminate_thread_ = false;
@@ -52,13 +42,10 @@ JointTrajectoryController::JointTrajectoryController(kinova::KinovaComm &kinova_
 
     // counter in the timer to publish joint velocity command: pub_joint_vel()
     traj_command_points_index_ = 0;
-
-    //ROS_DEBUG_STREAM_ONCE("Get out: " << __PRETTY_FUNCTION__);
 }
 
 JointTrajectoryController::~JointTrajectoryController()
 {
-    //ROS_DEBUG_STREAM_ONCE("Get in: " << __PRETTY_FUNCTION__);
     ROS_WARN("destruction entered!");
     {
         boost::mutex::scoped_lock terminate_lock(terminate_thread_mutex_);
@@ -72,35 +59,16 @@ JointTrajectoryController::~JointTrajectoryController()
     timer_pub_joint_vel_.stop();
     thread_update_state_->join();
     delete thread_update_state_;
-
-    //ROS_DEBUG_STREAM_ONCE("Get out: " << __PRETTY_FUNCTION__);
 }
 
 
 
 void JointTrajectoryController::commandCB(const trajectory_msgs::JointTrajectoryConstPtr &traj_msg)
 {
-    //ROS_DEBUG_STREAM_ONCE("Get in: " << __PRETTY_FUNCTION__);
-
     bool command_abort = false;
 
-//    // if receive new command, clear all trajectory and stop api
-//    kinova_comm_.stopAPI();
-//    if(!kinova_comm_.isStopped())
-//    {
-//        ros::Duration(0.01).sleep();
-//    }
-//    kinova_comm_.eraseAllTrajectories();
-
-//    kinova_comm_.startAPI();
-//    if(kinova_comm_.isStopped())
-//    {
-//        ros::Duration(0.01).sleep();
-//    }
-
     traj_command_points_ = traj_msg->points;
-    ROS_INFO_STREAM("Trajectory controller Receive trajectory with points number: " << traj_command_points_.size());
-
+    ROS_INFO_STREAM_NAMED("Trajectory controller", "Receive trajectory with points number: " << traj_command_points_.size());
     // Map the index in joint_names and the msg
     std::vector<int> lookup(number_joint_, -1);
 
@@ -139,9 +107,15 @@ void JointTrajectoryController::commandCB(const trajectory_msgs::JointTrajectory
             command_abort = true;
             break;
         }
-
+        // velocity should not be empty
+        if (traj_command_points_[j].velocities.empty()) 
+        {
+            ROS_ERROR_STREAM("Velocities in trajectory command cannot be empty at point: " << j);
+            command_abort = true;
+            break;
+        }
         // if velocity provided, size match
-        if (!traj_command_points_[j].velocities.empty() && traj_command_points_[j].velocities.size() != number_joint_)
+        if (traj_command_points_[j].velocities.size() != number_joint_)
         {
             ROS_ERROR_STREAM("Velocities at point " << j << " has size " << traj_command_points_[j].velocities.size() << " in trajectory command, which does not match joint number! ");
             command_abort = true;
@@ -153,22 +127,13 @@ void JointTrajectoryController::commandCB(const trajectory_msgs::JointTrajectory
         return;
 
     // store angle velocity command sent to robot
-//    std::vector<KinovaAngles> kinova_angle_command;
     kinova_angle_command_.resize(traj_command_points_.size());
     for (size_t i = 0; i<traj_command_points_.size(); i++)
     {
         kinova_angle_command_[i].InitStruct(); // initial joint velocity to zeros.
-
-        kinova_angle_command_[i].Actuator1 = traj_command_points_[i].velocities[0] *180/M_PI;
-        kinova_angle_command_[i].Actuator2 = traj_command_points_[i].velocities[1] *180/M_PI;
-        kinova_angle_command_[i].Actuator3 = traj_command_points_[i].velocities[2] *180/M_PI;
-        kinova_angle_command_[i].Actuator4 = traj_command_points_[i].velocities[3] *180/M_PI;
-        if (number_joint_>=6)
+        for(int actuator = 0; actuator < number_joint_; actuator++)
         {
-            kinova_angle_command_[i].Actuator5 = traj_command_points_[i].velocities[4] *180/M_PI;
-            kinova_angle_command_[i].Actuator6 = traj_command_points_[i].velocities[5] *180/M_PI;
-            if (number_joint_==7)
-                kinova_angle_command_[i].Actuator7 = traj_command_points_[i].velocities[6] *180/M_PI;
+            kinova_angle_command_[i][actuator] = traj_command_points_[i].velocities[actuator] *180/M_PI;
         }
     }
 
@@ -176,46 +141,33 @@ void JointTrajectoryController::commandCB(const trajectory_msgs::JointTrajectory
     double trajectory_duration = traj_command_points_[0].time_from_start.toSec();
 
     durations[0] = trajectory_duration;
-//    ROS_DEBUG_STREAM("durationsn 0 is: " << durations[0]);
 
     for (int i = 1; i<traj_command_points_.size(); i++)
     {
         durations[i] = (traj_command_points_[i].time_from_start - traj_command_points_[i-1].time_from_start).toSec();
         trajectory_duration += durations[i];
-//        ROS_DEBUG_STREAM("durations " << i << " is: " << durations[i]);
     }
 
     // start timer thread to publish joint velocity command
     time_pub_joint_vel_ = ros::Time::now();
     timer_pub_joint_vel_.start();
-
-    //ROS_DEBUG_STREAM_ONCE("Get out: " << __PRETTY_FUNCTION__);
 }
 
 
 void JointTrajectoryController::pub_joint_vel(const ros::TimerEvent&)
 {
     // send out each velocity command with corresponding duration delay.
-
     kinova_msgs::JointVelocity joint_velocity_msg;
 
     if (traj_command_points_index_ <  kinova_angle_command_.size() && ros::ok())
     {
-        joint_velocity_msg.joint1 = kinova_angle_command_[traj_command_points_index_].Actuator1;
-        joint_velocity_msg.joint2 = kinova_angle_command_[traj_command_points_index_].Actuator2;
-        joint_velocity_msg.joint3 = kinova_angle_command_[traj_command_points_index_].Actuator3;
-        joint_velocity_msg.joint4 = kinova_angle_command_[traj_command_points_index_].Actuator4;
-        joint_velocity_msg.joint5 = kinova_angle_command_[traj_command_points_index_].Actuator5;
-        joint_velocity_msg.joint6 = kinova_angle_command_[traj_command_points_index_].Actuator6;
-        joint_velocity_msg.joint7 = kinova_angle_command_[traj_command_points_index_].Actuator7;
-
-        // In debug: compare values with topic: follow_joint_trajectory/goal, command
-//        ROS_DEBUG_STREAM_ONCE( std::endl <<" joint_velocity_msg.joint1: " << joint_velocity_msg.joint1 * M_PI/180 <<
-//                          std::endl <<" joint_velocity_msg.joint2: " << joint_velocity_msg.joint2 * M_PI/180 <<
-//                          std::endl <<" joint_velocity_msg.joint3: " << joint_velocity_msg.joint3 * M_PI/180 <<
-//                          std::endl <<" joint_velocity_msg.joint4: " << joint_velocity_msg.joint4 * M_PI/180 <<
-//                          std::endl <<" joint_velocity_msg.joint5: " << joint_velocity_msg.joint5 * M_PI/180 <<
-//                          std::endl <<" joint_velocity_msg.joint6: " << joint_velocity_msg.joint6 * M_PI/180 );
+        joint_velocity_msg.joint1 = kinova_angle_command_[traj_command_points_index_][0];
+        joint_velocity_msg.joint2 = kinova_angle_command_[traj_command_points_index_][1];
+        joint_velocity_msg.joint3 = kinova_angle_command_[traj_command_points_index_][2];
+        joint_velocity_msg.joint4 = kinova_angle_command_[traj_command_points_index_][3];
+        joint_velocity_msg.joint5 = kinova_angle_command_[traj_command_points_index_][4];
+        joint_velocity_msg.joint6 = kinova_angle_command_[traj_command_points_index_][5];
+        joint_velocity_msg.joint7 = kinova_angle_command_[traj_command_points_index_][6];
 
         pub_joint_velocity_.publish(joint_velocity_msg);
 
@@ -243,8 +195,6 @@ void JointTrajectoryController::pub_joint_vel(const ros::TimerEvent&)
 
 void JointTrajectoryController::update_state()
 {
-    //ROS_DEBUG_STREAM_ONCE("Get in: " << __PRETTY_FUNCTION__);
-
     ros::Rate update_rate(10);
     previous_pub_ = ros::Time::now();
     while (nh_.ok())
@@ -268,41 +218,11 @@ void JointTrajectoryController::update_state()
         kinova_comm_.getJointAngles(current_joint_angles);
         kinova_comm_.getJointVelocities(current_joint_velocity);
 
-
-        traj_feedback_msg_.desired.positions[0] = current_joint_command.Actuators.Actuator1 *M_PI/180;
-        traj_feedback_msg_.desired.positions[1] = current_joint_command.Actuators.Actuator2 *M_PI/180;
-        traj_feedback_msg_.desired.positions[2] = current_joint_command.Actuators.Actuator3 *M_PI/180;
-        traj_feedback_msg_.desired.positions[3] = current_joint_command.Actuators.Actuator4 *M_PI/180;
-        if (number_joint_>=6)
+        for(int actuator = 0; actuator < number_joint_; actuator++)
         {
-            traj_feedback_msg_.desired.positions[4] = current_joint_command.Actuators.Actuator5 *M_PI/180;
-            traj_feedback_msg_.desired.positions[5] = current_joint_command.Actuators.Actuator6 *M_PI/180;
-            if (number_joint_==7)
-                traj_feedback_msg_.desired.positions[6] = current_joint_command.Actuators.Actuator7 *M_PI/180;
-        }
-
-        traj_feedback_msg_.actual.positions[0] = current_joint_angles.Actuator1 *M_PI/180;
-        traj_feedback_msg_.actual.positions[1] = current_joint_angles.Actuator2 *M_PI/180;
-        traj_feedback_msg_.actual.positions[2] = current_joint_angles.Actuator3 *M_PI/180;
-        traj_feedback_msg_.actual.positions[3] = current_joint_angles.Actuator4 *M_PI/180;
-        if (number_joint_>=6)
-        {
-            traj_feedback_msg_.actual.positions[4] = current_joint_angles.Actuator5 *M_PI/180;
-            traj_feedback_msg_.actual.positions[5] = current_joint_angles.Actuator6 *M_PI/180;
-            if (number_joint_==7)
-                traj_feedback_msg_.actual.positions[6] = current_joint_angles.Actuator7 *M_PI/180;
-        }
-
-        traj_feedback_msg_.actual.velocities[0] = current_joint_velocity.Actuator1 *M_PI/180;
-        traj_feedback_msg_.actual.velocities[1] = current_joint_velocity.Actuator2 *M_PI/180;
-        traj_feedback_msg_.actual.velocities[2] = current_joint_velocity.Actuator3 *M_PI/180;
-        traj_feedback_msg_.actual.velocities[3] = current_joint_velocity.Actuator4 *M_PI/180;
-        if (number_joint_>=6)
-        {
-            traj_feedback_msg_.actual.velocities[4] = current_joint_velocity.Actuator5 *M_PI/180;
-            traj_feedback_msg_.actual.velocities[5] = current_joint_velocity.Actuator6 *M_PI/180;
-            if (number_joint_==7)
-                traj_feedback_msg_.actual.velocities[6] = current_joint_velocity.Actuator7 *M_PI/180;
+            traj_feedback_msg_.desired.positions[actuator] = current_joint_command.Actuators[actuator] *M_PI/180;
+            traj_feedback_msg_.actual.positions[actuator] = current_joint_angles[actuator] *M_PI/180;
+            traj_feedback_msg_.actual.velocities[actuator] = current_joint_velocity[actuator] *M_PI/180;
         }
 
         for (size_t j = 0; j<joint_names_.size(); j++)
@@ -310,10 +230,8 @@ void JointTrajectoryController::update_state()
             traj_feedback_msg_.error.positions[j] = traj_feedback_msg_.actual.positions[j] - traj_feedback_msg_.desired.positions[j];
         }
 
-        //        ROS_WARN_STREAM("I'm publishing after second: " << (ros::Time::now() - previous_pub_).toSec());
         pub_joint_feedback_.publish(traj_feedback_msg_);
         previous_pub_ = ros::Time::now();
         update_rate.sleep();
     }
-    //ROS_DEBUG_STREAM_ONCE("Get out: " << __PRETTY_FUNCTION__);
 }


### PR DESCRIPTION
Hi,

TLDR: Improved the _Joint Trajectory Controller_ to actually be usable. Also smaller fixes in adjacent files.

I attempted to make use of the MoveIt Plugin and noticed a few major issues with the execution, at least on the j2s7s300.

This mostly stems from a seemingly unfinished _Joint Trajectory Controller_ class, which had a lot of debug outputs and unused code (especially in the header file). 

The result was, that MoveIt-generated trajectories were not followed to the last pose, as the previous joint trajectory controller work from a principle to simply set the velocities of the next pose to be reached. As the last pose of a trajectory generally has a velocity of zero, the robot stops one pose short.
I fixed this by calculating a remainder of time to continue motion during the approach of the final pose. Tests now show a remarkable difference, as the planned poses are now reached almost perfectly.

In the same run, I fixed some inconsistencies in the _Joint Trajectory Action Service_.