### PR TITLE
Adding option to launch file for respawning controller

### DIFF
--- a/kinova_bringup/launch/kinova_robot.launch
+++ b/kinova_bringup/launch/kinova_robot.launch
@@ -6,11 +6,12 @@
 	<arg name="kinova_robotSerial" default="not_set" />
 	<arg name="use_jaco_v1_fingers" default="false" />
 	<arg name="feedback_publish_rate" default="0.1" />
+	<arg name="respawn_driver" default="False" />
 
   <!-- If the node handles multiple robots uncomment this and configure /config/multiple_robots.yaml" -->
 	<!-- <rosparam file="$(find kinova_bringup)/launch/config/multiple_robots.yaml" command="load" /> -->
 
-  <node name="$(arg kinova_robotName)_driver" pkg="kinova_driver" type="kinova_arm_driver" output="screen" cwd="node" args="$(arg kinova_robotType)">
+  <node name="$(arg kinova_robotName)_driver" pkg="kinova_driver" type="kinova_arm_driver" output="screen" cwd="node" args="$(arg kinova_robotType)" respawn="$(arg respawn_driver)">
     <rosparam file="$(find kinova_bringup)/launch/config/robot_parameters.yaml" command="load" />
     <param name="serial_number" value="$(arg kinova_robotSerial)" />   
     <param name="robot_name" value="$(arg kinova_robotName)" />   


### PR DESCRIPTION
Respawning the node `kinova_arm_driver` automatically if an error has occurred. 
This is useful if a concurrent access to the interface of a robot from two driver nodes during the bringup of multiple robots. 